### PR TITLE
fix: resolve runtime error with unexpected keyword

### DIFF
--- a/t4_devkit/viewer/rendering_data/segmentation.py
+++ b/t4_devkit/viewer/rendering_data/segmentation.py
@@ -62,4 +62,4 @@ class SegmentationData2D:
         for mask, class_id in zip(self._masks, self._class_ids, strict=True):
             image[mask == 1] == class_id
 
-        return rr.SegmentationImage(data=image)
+        return rr.SegmentationImage(image=image)


### PR DESCRIPTION
## What

This PR fixes runtime error during rendering segmentation image as follows:

```python
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 750, in render_scene
    self._render_annotation_2ds(viewer, scene.first_sample_token, max_timestamp_us)
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 1171, in _render_annotation_2ds
    viewer.render_segmentation2d(
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/viewer/viewer.py", line 247, in render_segmentation2d
    segmentation_data.as_segmentation_image(),
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/viewer/rendering_data/segmentation.py", line 65, in as_segmentation_image
    return rr.SegmentationImage(data=image)
TypeError: SegmentationImageExt.__init__() got an unexpected keyword argument 'data'
```