### PR TITLE
refactor: update Tier4 API to avoid runtime errors for irregular data

### DIFF
--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -186,11 +186,12 @@ class Tier4:
             record.category_name = category.name
 
         for record in self.object_ann:
-            instance: Instance = self.get("instance", record.instance_token)
-            category: Category = self.get("category", instance.category_token)
+            category: Category = self.get("category", record.category_token)
             record.category_name = category.name
 
         for record in self.surface_ann:
+            if record.category_token == "":  # NOTE: Some database contains this case
+                continue
             category: Category = self.get("category", record.category_token)
             record.category_name = category.name
 


### PR DESCRIPTION
## What

This PR updates Tier4 API to avoid runtime errors for irregular data as follows:

Case1:

Invalid instance token is contained in `object_ann`.

```shell
Creating data info for scene: 70891309-ca8b-477b-905a-5156ffb3df65
Traceback (most recent call last):
  File "/workspace/tools/detection3d/create_data_t4dataset.py", line 290, in <module>
    main()
  File "/workspace/tools/detection3d/create_data_t4dataset.py", line 263, in main
    t4 = Tier4(
  File "/opt/conda/lib/python3.10/site-packages/t4_devkit/tier4.py", line 128, in __init__
    self.__make_reverse_index__(verbose)
  File "/opt/conda/lib/python3.10/site-packages/t4_devkit/tier4.py", line 189, in __make_reverse_index__
    instance: Instance = self.get("instance", record.instance_token)
  File "/opt/conda/lib/python3.10/site-packages/t4_devkit/tier4.py", line 262, in get
    return self.get_table(schema)[self.get_idx(schema, token)]
  File "/opt/conda/lib/python3.10/site-packages/t4_devkit/tier4.py", line 278, in get_idx
    raise KeyError(f"{token} is not registered in {schema}.")
KeyError: '89338d1d0b3e8ab40b363e4b84cfb7d0 is not registered in instance.'
```

In order to avoid this case,  Tier4 API access `category_token` directory.

Case2:

Empty category token in assigned to `surface_ann`.

```shell
Reverse indexing...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 128, in __init__
    self.__make_reverse_index__(verbose)
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 193, in __make_reverse_index__
    category: Category = self.get("category", record.category_token)
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 261, in get
    return self.get_table(schema)[self.get_idx(schema, token)]
  File "/home/ktro2828/workspace/t4-devkit/t4_devkit/tier4.py", line 277, in get_idx
    raise KeyError(f"{token} is not registered in {schema}.")
KeyError: ' is not registered in category.'
```

In this case, Tier4 API skips to set corresponding category name.
