### PR TITLE
feat(dataclass): add serialization function

### DIFF
--- a/docs/apis/common.md
+++ b/docs/apis/common.md
@@ -1,9 +1,13 @@
 # `common`
 
 <!-- prettier-ignore-start -->
+::: t4_devkit.common.converter
+
 ::: t4_devkit.common.geometry
 
 ::: t4_devkit.common.io
+
+::: t4_devkit.common.serialize
 
 ::: t4_devkit.common.timestamp
 <!-- prettier-ignore-end -->

--- a/t4_devkit/common/serialize.py
+++ b/t4_devkit/common/serialize.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+import numpy as np
+from attrs import asdict, fields, filters
+from pyquaternion import Quaternion
+
+
+def serialize_dataclass(data: Any) -> dict[str, Any]:
+    """Serialize attrs' dataclasses into dict.
+
+    Note that all fields specified with `init=False` will be skipped to be serialized.
+
+    Args:
+        data (Any): Dataclass object.
+
+    Returns:
+        dict[str, Any]: Serialized dict.
+    """
+    excludes = filters.exclude(*[a for a in fields(data.__class__) if not a.init])
+    return asdict(data, filter=excludes, value_serializer=_value_serializer)
+
+
+def _value_serializer(data: Any, attribute: Any, value: Any) -> Any:
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+    elif isinstance(value, Quaternion):
+        return value.q.tolist()
+    elif isinstance(value, tuple):
+        return list(value)
+    elif isinstance(value, Enum):
+        return value.value
+    return value

--- a/t4_devkit/schema/serialize.py
+++ b/t4_devkit/schema/serialize.py
@@ -1,11 +1,8 @@
 from __future__ import annotations
 
-from enum import Enum
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
-import numpy as np
-from attrs import asdict, filters
-from pyquaternion import Quaternion
+from t4_devkit.common.serialize import serialize_dataclass
 
 if TYPE_CHECKING:
     from .tables import SchemaTable
@@ -35,17 +32,4 @@ def serialize_schema(data: SchemaTable) -> dict:
     Returns:
         Serialized dict data.
     """
-    excludes = filters.exclude(*data.shortcuts()) if data.shortcuts() is not None else None
-    return asdict(data, filter=excludes, value_serializer=_value_serializer)
-
-
-def _value_serializer(data: SchemaTable, attr: Any, value: Any) -> Any:
-    if isinstance(value, np.ndarray):
-        return value.tolist()
-    elif isinstance(value, Quaternion):
-        return value.q.tolist()
-    elif isinstance(value, tuple):
-        return list(value)
-    elif isinstance(value, Enum):
-        return value.value
-    return value
+    return serialize_dataclass(data)

--- a/t4_devkit/schema/tables/base.py
+++ b/t4_devkit/schema/tables/base.py
@@ -17,15 +17,6 @@ class SchemaBase(ABC):
 
     token: str
 
-    @staticmethod
-    def shortcuts() -> tuple[str, ...] | None:
-        """Return a sequence of shortcut field names.
-
-        Returns:
-            Returns None if there is no shortcut. Otherwise, returns sequence of shortcut field names.
-        """
-        return None
-
     @classmethod
     def from_json(cls, filepath: str) -> list[SchemaTable]:
         """Construct dataclass from json file.

--- a/t4_devkit/schema/tables/log.py
+++ b/t4_devkit/schema/tables/log.py
@@ -34,7 +34,3 @@ class Log(SchemaBase):
 
     # shortcuts
     map_token: str = field(init=False, factory=str)
-
-    @staticmethod
-    def shortcuts() -> tuple[str]:
-        return ("map_token",)

--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -76,10 +76,6 @@ class ObjectAnn(SchemaBase):
     # shortcuts
     category_name: str = field(init=False, factory=str)
 
-    @staticmethod
-    def shortcuts() -> tuple[str]:
-        return ("category_name",)
-
     @property
     def width(self) -> int:
         """Return the width of the bounding box.

--- a/t4_devkit/schema/tables/sample.py
+++ b/t4_devkit/schema/tables/sample.py
@@ -43,7 +43,3 @@ class Sample(SchemaBase):
     ann_3ds: list[str] = field(factory=list, init=False)
     ann_2ds: list[str] = field(factory=list, init=False)
     surface_anns: list[str] = field(factory=list, init=False)
-
-    @staticmethod
-    def shortcuts() -> tuple[str, str, str, str]:
-        return ("data", "ann_3ds", "ann_2ds", "surface_anns")

--- a/t4_devkit/schema/tables/sample_annotation.py
+++ b/t4_devkit/schema/tables/sample_annotation.py
@@ -70,7 +70,3 @@ class SampleAnnotation(SchemaBase):
 
     # shortcuts
     category_name: str = field(init=False, factory=str)
-
-    @staticmethod
-    def shortcuts() -> tuple[str]:
-        return ("category_name",)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -106,7 +106,3 @@ class SampleData(SchemaBase):
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)
     channel: str = field(init=False, factory=str)
-
-    @staticmethod
-    def shortcuts() -> tuple[str, str]:
-        return ("modality", "channel")

--- a/t4_devkit/schema/tables/sensor.py
+++ b/t4_devkit/schema/tables/sensor.py
@@ -45,7 +45,3 @@ class Sensor(SchemaBase):
 
     # shortcuts
     first_sd_token: str = field(init=False, factory=str)
-
-    @staticmethod
-    def shortcuts() -> tuple[str] | None:
-        return ("first_sd_token",)

--- a/t4_devkit/schema/tables/surface_ann.py
+++ b/t4_devkit/schema/tables/surface_ann.py
@@ -39,10 +39,6 @@ class SurfaceAnn(SchemaBase):
     # shortcuts
     category_name: str = field(init=False, factory=str)
 
-    @staticmethod
-    def shortcuts() -> tuple[str]:
-        return ("category_name",)
-
     @property
     def bbox(self) -> RoiType:
         """Return a bounding box corners calculated from polygon vertices.


### PR DESCRIPTION
## What

This PR introduces following changes:

- Add a function to serialize dataclasses defined by `attrs`, which is called `serialize_dataclass`.
- The internal works of `serialize_schema` is replaced by `serialize_dataclass`.
  - By this change, no need to use `shortcuts` methods anymore, then they are removed.