### PR TITLE
feat(visualize): add support of loading global map origin from yaml

### DIFF
--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import rerun as rr
+import yaml
 from PIL import Image
 from pyquaternion import Quaternion
 
@@ -918,6 +919,15 @@ class Tier4:
         if render_annotation:
             viewer = viewer.with_labels(self._label2id)
 
+        global_map_filepath = osp.join(self.data_root, "map/global_map_center.pcd.yaml")
+        if osp.exists(global_map_filepath):
+            with open(global_map_filepath) as f:
+                map_metadata: dict = yaml.safe_load(f)
+            map_origin: dict = map_metadata["/**"]["ros__parameters"]["map_origin"]
+            latitude = map_origin["latitude"]
+            longitude = map_origin["longitude"]
+            viewer = viewer.with_global_origin((latitude, longitude))
+
         print(f"Finish initializing {application_id} ...")
 
         return viewer
@@ -1230,4 +1240,5 @@ def _append_mask(
         camera_masks[camera]["masks"] = [ann.mask.decode()]
         camera_masks[camera]["class_ids"] = [class_id]
         camera_masks[camera]["uuids"] = [class_id]
+    return camera_masks
     return camera_masks

--- a/t4_devkit/viewer/__init__.py
+++ b/t4_devkit/viewer/__init__.py
@@ -1,2 +1,3 @@
 from .color import *  # noqa
+from .geography import *  # noqa
 from .viewer import *  # noqa

--- a/t4_devkit/viewer/geography.py
+++ b/t4_devkit/viewer/geography.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from t4_devkit.typing import TranslationType
+
+
+__all__ = ["calculate_geodetic_point"]
+
+EARTH_RADIUS_METERS = 6.378137e6
+FLATTENING = 1 / 298.257223563
+
+
+def calculate_geodetic_point(
+    position: TranslationType,
+    origin: tuple[float, float],
+) -> tuple[float, float]:
+    """Transform a position in a map coordinate system to a position in a geodetic coordinate system.
+
+    Args:
+        position (TranslationType): 3D position in a map coordinate system.
+        origin (tuple[float, float]): Map origin position in a geodetic coordinate system,
+            which is (latitude, longitude).
+
+    Returns:
+        tuple[float, float]: Transformed position in a geodetic coordinate system,
+            which is (latitude, longitude).
+    """
+    x, y, _ = position
+    bearing = math.atan2(x, y)
+    distance = math.hypot(x, y)
+
+    latitude, longitude = np.radians(origin)
+    angular_distance = distance / EARTH_RADIUS_METERS
+
+    target_latitude = math.asin(
+        math.sin(latitude) * math.cos(angular_distance)
+        + math.cos(latitude) * math.sin(angular_distance) * math.cos(bearing)
+    )
+    target_longitude = longitude + math.atan2(
+        math.sin(bearing) * math.sin(angular_distance) * math.cos(latitude),
+        math.cos(angular_distance) - math.sin(latitude) * math.sin(target_latitude),
+    )
+
+    return math.degrees(target_latitude), math.degrees(target_longitude)


### PR DESCRIPTION
## What

This PR introduces rendering geometric coordinates from the global map origin and ego position at the particular timestamp even if `EgoPose.geocoordinate` is `None`.

The global map origin is parsed from `map/global_map_center.pcd.yaml` if it is contained.
The expected format of `global_map_center.pcd.yaml` is as follows:

```yaml
/**:
  ros__parameters:
    map_origin:
      latitude: 35.223124955115864
      longitude: 138.80245834628386
      elevation: 0.0
      roll: 0.0
      pitch: 0.0
      yaw: 0.0
```