### PR TITLE
refactor: ensure enum members are unique

### DIFF
--- a/t4_devkit/schema/name.py
+++ b/t4_devkit/schema/name.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, unique
 
 __all__ = ("SchemaName",)
 
 
+@unique
 class SchemaName(str, Enum):
     """An enum to represent schema filenames.
 

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, unique
 from typing import TYPE_CHECKING
 
 from attrs import define, field
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 __all__ = ["SampleData", "FileFormat"]
 
 
+@unique
 class FileFormat(str, Enum):
     """An enum to represent file formats.
 

--- a/t4_devkit/schema/tables/sensor.py
+++ b/t4_devkit/schema/tables/sensor.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, unique
 
 from attrs import define, field
 
@@ -11,6 +11,7 @@ from .registry import SCHEMAS
 __all__ = ("Sensor", "SensorModality")
 
 
+@unique
 class SensorModality(str, Enum):
     """An enum to represent sensor modalities.
 

--- a/t4_devkit/schema/tables/vehicle_state.py
+++ b/t4_devkit/schema/tables/vehicle_state.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, unique
 
 from attrs import define, field
 
@@ -11,6 +11,7 @@ from .registry import SCHEMAS
 __all__ = ["ShiftState", "IndicatorState", "Indicators", "AdditionalInfo", "VehicleState"]
 
 
+@unique
 class ShiftState(str, Enum):
     """An enum to represent gear shift state."""
 
@@ -23,6 +24,7 @@ class ShiftState(str, Enum):
     NONE = "NONE"
 
 
+@unique
 class IndicatorState(str, Enum):
     """An enum to represent indicator state."""
 

--- a/t4_devkit/schema/tables/visibility.py
+++ b/t4_devkit/schema/tables/visibility.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from enum import Enum
+from enum import Enum, unique
 
 from attrs import define, field
 from typing_extensions import Self
@@ -13,6 +13,7 @@ from .registry import SCHEMAS
 __all__ = ("Visibility", "VisibilityLevel")
 
 
+@unique
 class VisibilityLevel(str, Enum):
     """An enum to represent visibility levels.
 


### PR DESCRIPTION
## What

This PR uses `@unique` decorator in order to ensure enum members are unqiue.