### PR TITLE
refactor: rename FilterByAre to FilterByRegion

### DIFF
--- a/t4_devkit/filtering/compose.py
+++ b/t4_devkit/filtering/compose.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Sequence
 
 from .functional import (
-    FilterByArea,
     FilterByDistance,
     FilterByLabel,
     FilterByNumPoints,
+    FilterByRegion,
     FilterBySpeed,
     FilterByUUID,
 )
@@ -32,7 +32,7 @@ class BoxFilter:
             FilterByLabel.from_params(params),
             FilterByUUID.from_params(params),
             FilterByDistance.from_params(params),
-            FilterByArea.from_params(params),
+            FilterByRegion.from_params(params),
             FilterBySpeed.from_params(params),
             FilterByNumPoints.from_params(params),
         ]

--- a/t4_devkit/filtering/functional.py
+++ b/t4_devkit/filtering/functional.py
@@ -18,7 +18,7 @@ __all__ = [
     "FilterByLabel",
     "FilterByUUID",
     "FilterByDistance",
-    "FilterByArea",
+    "FilterByRegion",
     "BoxFilterFunction",
 ]
 
@@ -139,8 +139,8 @@ class FilterByDistance(BaseBoxFilter):
             return self.min_distance < box_distance and box_distance < self.max_distance
 
 
-class FilterByArea(BaseBoxFilter):
-    """Filter a box by checking if the box xy position is within the specified xy area.
+class FilterByRegion(BaseBoxFilter):
+    """Filter a box by checking if the box xy position is within the specified xy region.
 
     Note that, the type box is `Box2D` and its `position` is None,
     these boxes pass through this filter.

--- a/tests/fitering/test_filter_function.py
+++ b/tests/fitering/test_filter_function.py
@@ -1,8 +1,8 @@
 from t4_devkit.filtering.functional import (
-    FilterByArea,
     FilterByDistance,
     FilterByLabel,
     FilterByNumPoints,
+    FilterByRegion,
     FilterBySpeed,
     FilterByUUID,
 )
@@ -66,15 +66,15 @@ def test_filter_by_distance(dummy_box3ds, dummy_box2ds, dummy_tf_buffer) -> None
     assert len(answer2d) == 3
 
 
-def test_filter_by_position(dummy_box3ds, dummy_box2ds, dummy_tf_buffer) -> None:
-    """Test `FilterByArea`.
+def test_filter_by_Region(dummy_box3ds, dummy_box2ds, dummy_tf_buffer) -> None:
+    """Test `FilterByRegion`.
 
     Args:
         dummy_box3ds (list[Box3D]): List of 3D boxes.
         dummy_box2ds (list[Box2D]): List of 2D boxes.
         dummy_tf_buffer (TransformBuffer): Transformation buffer.
     """
-    box_filter = FilterByArea(min_xy=(0.0, 0.0), max_xy=(10.0, 10.0))
+    box_filter = FilterByRegion(min_xy=(0.0, 0.0), max_xy=(10.0, 10.0))
 
     answer3d = [
         box


### PR DESCRIPTION
## What

Rename filtering function from `FilterByAre` to `FilterByRegion`.