### PR TITLE
fix: replace np.array instead of np.asarray in dataclass constructors

### DIFF
--- a/t4_devkit/common/converter.py
+++ b/t4_devkit/common/converter.py
@@ -8,10 +8,10 @@ from pyquaternion import Quaternion
 if TYPE_CHECKING:
     from t4_devkit.typing import ArrayLike, NDArray
 
-__all__ = ["as_quaternion"]
+__all__ = ["to_quaternion"]
 
 
-def as_quaternion(value: ArrayLike | NDArray) -> Quaternion:
+def to_quaternion(value: ArrayLike | NDArray) -> Quaternion:
     """Convert input rotation like array to `Quaternion`.
 
     Args:

--- a/t4_devkit/dataclass/box.py
+++ b/t4_devkit/dataclass/box.py
@@ -8,7 +8,7 @@ from attrs.converters import optional
 from shapely.geometry import Polygon
 from typing_extensions import Self
 
-from t4_devkit.common.converter import as_quaternion
+from t4_devkit.common.converter import to_quaternion
 
 from .roi import Roi
 from .trajectory import to_trajectories
@@ -111,10 +111,10 @@ class Box3D(BaseBox):
         ... )
     """
 
-    position: TranslationType = field(converter=np.asarray)
-    rotation: RotationType = field(converter=as_quaternion)
+    position: TranslationType = field(converter=np.array)
+    rotation: RotationType = field(converter=to_quaternion)
     shape: Shape
-    velocity: VelocityType | None = field(default=None, converter=optional(np.asarray))
+    velocity: VelocityType | None = field(default=None, converter=optional(np.array))
     num_points: int | None = field(default=None)
 
     # additional attributes: set by `with_**`

--- a/t4_devkit/dataclass/pointcloud.py
+++ b/t4_devkit/dataclass/pointcloud.py
@@ -25,10 +25,10 @@ __all__ = [
 class PointCloud:
     """Abstract base dataclass for pointcloud data."""
 
-    points: NDArrayFloat = field(converter=np.asarray)
+    points: NDArrayFloat = field(converter=np.array)
 
     @points.validator
-    def check_dims(self, attribute, value) -> None:
+    def _check_dims(self, attribute, value) -> None:
         if value.shape[0] != self.num_dims():
             raise ValueError(
                 f"Expected point dimension is {self.num_dims()}, but got {value.shape[0]}"
@@ -211,7 +211,7 @@ class SegmentationPointCloud(PointCloud):
         labels (NDArrayU8): Label matrix.
     """
 
-    labels: NDArrayU8 = field(converter=lambda x: np.asarray(x, dtype=np.uint8))
+    labels: NDArrayU8 = field(converter=lambda x: np.array(x, dtype=np.uint8))
 
     @staticmethod
     def num_dims() -> int:

--- a/t4_devkit/dataclass/roi.py
+++ b/t4_devkit/dataclass/roi.py
@@ -20,10 +20,12 @@ class Roi:
 
     roi: RoiType = field(converter=tuple)
 
-    def __attrs_post_init__(self) -> None:
-        assert len(self.roi) == 4, (
-            "Expected roi is (x, y, width, height), " f"but got length with {len(self.roi)}."
-        )
+    @roi.validator
+    def _check_dims(self, attribute, value) -> None:
+        if len(value) != 4:
+            raise ValueError(
+                f"Expected {attribute.name} is (x, y, width, height), but got length with {value}."
+            )
 
     @property
     def offset(self) -> tuple[int, int]:

--- a/t4_devkit/dataclass/shape.py
+++ b/t4_devkit/dataclass/shape.py
@@ -52,7 +52,7 @@ class Shape:
     """
 
     shape_type: ShapeType
-    size: SizeType = field(converter=np.asarray)
+    size: SizeType = field(converter=np.array)
     footprint: Polygon = field(default=None)
 
     def __attrs_post_init__(self) -> None:

--- a/t4_devkit/dataclass/trajectory.py
+++ b/t4_devkit/dataclass/trajectory.py
@@ -41,12 +41,13 @@ class Trajectory:
         [2. 2. 2.]
     """
 
-    waypoints: TrajectoryType = field(converter=np.asarray)
+    waypoints: TrajectoryType = field(converter=np.array)
     confidence: float = field(default=1.0)
 
-    def __attrs_post_init__(self) -> None:
-        if self.waypoints.shape[1] != 3:
-            raise ValueError("Trajectory dimension must be 3.")
+    @waypoints.validator
+    def _check_dims(self, attribute, value) -> None:
+        if value.shape[1] != 3:
+            raise ValueError(f"{attribute.name} dimension must be 3.")
 
     def __len__(self) -> int:
         return len(self.waypoints)

--- a/t4_devkit/dataclass/transform.py
+++ b/t4_devkit/dataclass/transform.py
@@ -8,7 +8,7 @@ from attrs import define, field
 from pyquaternion import Quaternion
 from typing_extensions import Self
 
-from t4_devkit.common.converter import as_quaternion
+from t4_devkit.common.converter import to_quaternion
 from t4_devkit.typing import NDArray, RotationType
 
 if TYPE_CHECKING:
@@ -108,8 +108,8 @@ class TransformBuffer:
 
 @define
 class HomogeneousMatrix:
-    position: TranslationType = field(converter=np.asarray)
-    rotation: Quaternion = field(converter=as_quaternion)
+    position: TranslationType = field(converter=np.array)
+    rotation: Quaternion = field(converter=to_quaternion)
     src: str
     dst: str
     matrix: NDArray = field(init=False)
@@ -498,7 +498,7 @@ def _generate_homogeneous_matrix(
         A 4x4 homogeneous matrix.
     """
     position = np.asarray(position)
-    rotation = as_quaternion(rotation)
+    rotation = to_quaternion(rotation)
 
     matrix = np.eye(4)
     matrix[:3, 3] = position

--- a/t4_devkit/schema/tables/calibrated_sensor.py
+++ b/t4_devkit/schema/tables/calibrated_sensor.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 from attrs import define, field
 
-from t4_devkit.common.converter import as_quaternion
+from t4_devkit.common.converter import to_quaternion
 
 from ..name import SchemaName
 from .base import SchemaBase
@@ -32,7 +32,7 @@ class CalibratedSensor(SchemaBase):
     """
 
     sensor_token: str
-    translation: TranslationType = field(converter=np.asarray)
-    rotation: RotationType = field(converter=as_quaternion)
-    camera_intrinsic: CamIntrinsicType = field(converter=np.asarray)
-    camera_distortion: CamDistortionType = field(converter=np.asarray)
+    translation: TranslationType = field(converter=np.array)
+    rotation: RotationType = field(converter=to_quaternion)
+    camera_intrinsic: CamIntrinsicType = field(converter=np.array)
+    camera_distortion: CamDistortionType = field(converter=np.array)

--- a/t4_devkit/schema/tables/ego_pose.py
+++ b/t4_devkit/schema/tables/ego_pose.py
@@ -4,8 +4,9 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import define, field
+from attrs.converters import optional
 
-from t4_devkit.common.converter import as_quaternion
+from t4_devkit.common.converter import to_quaternion
 
 from ..name import SchemaName
 from .base import SchemaBase
@@ -42,15 +43,9 @@ class EgoPose(SchemaBase):
             (latitude, longitude, altitude) in degrees and meters.
     """
 
-    translation: TranslationType = field(converter=np.asarray)
-    rotation: RotationType = field(converter=as_quaternion)
+    translation: TranslationType = field(converter=np.array)
+    rotation: RotationType = field(converter=to_quaternion)
     timestamp: int
-    twist: TwistType | None = field(
-        default=None, converter=lambda x: np.asarray(x) if x is not None else x
-    )
-    acceleration: AccelerationType | None = field(
-        default=None, converter=lambda x: np.asarray(x) if x is not None else x
-    )
-    geocoordinate: GeoCoordinateType | None = field(
-        default=None, converter=lambda x: np.asarray(x) if x is not None else x
-    )
+    twist: TwistType | None = field(default=None, converter=optional(np.array))
+    acceleration: AccelerationType | None = field(default=None, converter=optional(np.array))
+    geocoordinate: GeoCoordinateType | None = field(default=None, converter=optional(np.array))

--- a/t4_devkit/schema/tables/keypoint.py
+++ b/t4_devkit/schema/tables/keypoint.py
@@ -32,5 +32,5 @@ class Keypoint(SchemaBase):
     sample_data_token: str
     instance_token: str
     category_tokens: list[str]
-    keypoints: KeypointType = field(converter=np.asarray)
+    keypoints: KeypointType = field(converter=np.array)
     num_keypoints: int

--- a/t4_devkit/schema/tables/sample_annotation.py
+++ b/t4_devkit/schema/tables/sample_annotation.py
@@ -6,7 +6,7 @@ import numpy as np
 from attrs import define, field
 from attrs.converters import optional
 
-from t4_devkit.common.converter import as_quaternion
+from t4_devkit.common.converter import to_quaternion
 
 from ..name import SchemaName
 from .base import SchemaBase
@@ -58,15 +58,15 @@ class SampleAnnotation(SchemaBase):
     instance_token: str
     attribute_tokens: list[str]
     visibility_token: str
-    translation: TranslationType = field(converter=np.asarray)
-    size: SizeType = field(converter=np.asarray)
-    rotation: RotationType = field(converter=as_quaternion)
+    translation: TranslationType = field(converter=np.array)
+    size: SizeType = field(converter=np.array)
+    rotation: RotationType = field(converter=to_quaternion)
     num_lidar_pts: int
     num_radar_pts: int
     next: str  # noqa: A003
     prev: str
-    velocity: VelocityType | None = field(default=None, converter=optional(np.asarray))
-    acceleration: AccelerationType | None = field(default=None, converter=optional(np.asarray))
+    velocity: VelocityType | None = field(default=None, converter=optional(np.array))
+    acceleration: AccelerationType | None = field(default=None, converter=optional(np.array))
 
     # shortcuts
     category_name: str = field(init=False, factory=str)

--- a/t4_devkit/schema/tables/vehicle_state.py
+++ b/t4_devkit/schema/tables/vehicle_state.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from enum import Enum, unique
 
 from attrs import define, field
+from attrs.converters import optional
 
 from ..name import SchemaName
 from .base import SchemaBase
@@ -83,9 +84,7 @@ class VehicleState(SchemaBase):
     steer_pedal: float | None = field(default=None)
     steering_tire_angle: float | None = field(default=None)
     steering_wheel_angle: float | None = field(default=None)
-    shift_state: ShiftState | None = field(
-        default=None, converter=lambda x: None if x is None else ShiftState(x)
-    )
+    shift_state: ShiftState | None = field(default=None, converter=optional(ShiftState))
     indicators: Indicators | None = field(
         default=None, converter=lambda x: Indicators(**x) if isinstance(x, dict) else x
     )


### PR DESCRIPTION
## What

This PR replaces `np.asarray` in converters in each dataclass into `np.asarray`.
Because `np.asarray` doesn't create a copy of the input if it is already ndarray, the original values are changed unexpectedly if a destructive method is called, such as `Box3D.translate(...)`.

### Experiment

Test code is as follows:

```python
from t4_devkit import Tier4

t4 = Tier4("annotation", <DATA_ROOT>, verbose=False)

print(t4.sample_annotation[0].translation)

# Destructive methods, which are Box3D.translate(...) and Box3D.rotate(...) is invoked under the hood.
t4.get_sample_data(t4.sample_data[0].token)  

print(t4.sample_annotation[0].translation)
```

#### Before

Then the output shows the original has been changed.

```shell
[8.9548508e+04 4.2286165e+04 7.9690000e+00]
[-6.61751375 -4.48131001  1.01779332]
```

#### After

As of this PR, there is no change between before and after calling destructive methods.

```shell
[8.9548508e+04 4.2286165e+04 7.9690000e+00]
[8.9548508e+04 4.2286165e+04 7.9690000e+00]
```