### PR TITLE
feat: add CLI tool for visualization

### DIFF
--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -1,0 +1,68 @@
+## Command Line Tools
+
+### CLI Support
+
+Following command line tools are supported:
+
+- `t4viz`: Visualize T4 dataset features.
+
+To enable shell completion, please run following commands:
+
+### Shell Completion
+
+#### Bash
+
+```shell
+_T4VIZ_COMPLETE=bash_source t4viz > $HOME/.t4viz-complete.bash
+
+echo "source $HOME/.t4viz-complete.bash" >> ~/.bashrc
+```
+
+#### Fish
+
+```shell
+_T4VIZ_COMPLETE=fish_source t4viz > $HOME/.config/fish/completions/t4viz.fish
+```
+
+###
+
+### `t4viz`
+
+#### Visualize a Scene
+
+```shell
+t4viz scene <DATA_ROOT> [OPTIONS]
+```
+
+Arguments
+
+- `<DATA_ROOT>`: Root directory path to T4 dataset.
+- `-f, --future <SECONDS>`: Future time seconds.
+- `-o, --output <OUTPUT_DIR>`: Directory path to save recording `.rrd` file.
+- `--no-show`: Indicates whether not to show viewer.
+
+#### Visualize a Specific Instance
+
+```shell
+t4viz instance <DATA_ROOT> <INSTANCE_TOKEN> [OPTIONS]
+```
+
+Arguments
+
+- `<DATA_ROOT>`: Root directory path to T4 dataset.
+- `<INSTANCE_TOKEN>`: Unique identifier token of an instance record.
+- `-f, --future <SECONDS>`: Future time seconds.
+- `-o, --output <OUTPUT_DIR>`: Directory path to save recording `.rrd` file.
+- `--no-show`: Indicates whether not to show viewer.
+
+#### Visualize PointCloud
+
+```shell
+t4viz pointcloud <DATA_ROOT> [OPTIONS]
+```
+
+- `<DATA_ROOT>`: Root directory path to T4 dataset.
+- `<INSTANCE_TOKEN>`: Unique identifier token of an instance record.
+- `-d, --distortion`: Indicates whether not to ignore camera distortion.
+- `-o, --output <OUTPUT_DIR>`: Directory path to save recording `.rrd` file.
+- `--no-show`: Indicates whether not to show viewer.

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -8,6 +8,7 @@ nav:
       - Initialization: tutorials/initialize.md
       - Visualization: tutorials/render.md
       - Customization: tutorials/customize.md
+      - CLI: tutorials/cli.md
   - API:
       - TIER IV: apis/tier4.md
       - Schema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ dev = [
     "ruff>=0.8",
 ]
 
+[project.scripts]
+t4viz = "t4_devkit.cli.visualize:main"
+
 [tool.ruff]
 line-length = 100
 

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import os
+
+import click
+
+from t4_devkit import Tier4
+
+
+@click.group(invoke_without_command=True)
+@click.pass_context
+def main(ctx: click.Context) -> None:
+    if ctx.invoked_subcommand is None:
+        print(ctx.get_help())
+    else:
+        ctx.invoked_subcommand
+
+
+@main.command(name="scene", help="Visualize a specific scene.")
+@click.argument("data_root", type=click.Path(exists=True))
+@click.option("-f", "--future", type=float, default=0.0, help="Future time seconds.")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(writable=True),
+    help="Output directory to save recoding .rrd file.",
+)
+@click.option("--no-show", is_flag=True, help="Indicates whether not to show viewer.")
+def scene(data_root: str, output: str | None, future: float, no_show: bool) -> None:
+    _create_dir(output)
+
+    t4 = Tier4("annotation", data_root, verbose=False)
+    scene_token = t4.scene[0].token
+    t4.render_scene(scene_token, future_seconds=future, save_dir=output, show=not no_show)
+
+
+@main.command(name="instance", help="Visualize a particular instance in a corresponding scene")
+@click.argument("data_root", type=click.Path(exists=True))
+@click.argument("instance", type=click.STRING)
+@click.option("-f", "--future", type=float, default=0.0, help="Future time seconds.")
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(writable=True),
+    help="Output directory to save recoding .rrd file.",
+)
+@click.option("--no-show", is_flag=True, help="Indicates whether not to show viewer.")
+def instance(
+    data_root: str, instance: str, future: float, output: str | None, no_show: bool
+) -> None:
+    _create_dir(output)
+
+    t4 = Tier4("annotation", data_root, verbose=False)
+    t4.render_instance(
+        instance_token=instance, future_seconds=future, save_dir=output, show=not no_show
+    )
+
+
+@main.command(name="pointcloud", help="Visualize pointcloud in a corresponding scene.")
+@click.argument("data_root", type=click.Path(exists=True))
+@click.option(
+    "-d",
+    "--distortion",
+    is_flag=True,
+    help="Indicates whether not to ignore camera distortion.",
+)
+@click.option(
+    "-o",
+    "--output",
+    type=click.Path(writable=True),
+    help="Output directory to save recoding .rrd file.",
+)
+@click.option("--no-show", is_flag=True, help="Indicates whether not to show viewer.")
+def pointcloud(data_root: str, distortion: bool, output: str | None, no_show: bool) -> None:
+    _create_dir(output)
+
+    t4 = Tier4("annotation", data_root, verbose=False)
+    scene_token = t4.scene[0].token
+    t4.render_pointcloud(
+        scene_token,
+        ignore_distortion=not distortion,
+        save_dir=output,
+        show=not no_show,
+    )
+
+
+def _create_dir(dir_path: str) -> None:
+    """Create a directory with the specified path.
+    If the input path is `None` this function does nothing.
+    Args:
+        dir_path (str | None): Directory path to create.
+    """
+    if dir_path is not None:
+        os.makedirs(dir_path, exist_ok=True)


### PR DESCRIPTION
## What

This PR introduces a CLI tool to visualize T4 dataset.

### Usage

```shell
$ t4viz --help
Usage: t4viz [OPTIONS] COMMAND [ARGS]...

Options:
  --help  Show this message and exit.

Commands:
  instance    Visualize a particular instance in a corresponding scene
  pointcloud  Visualize pointcloud in a corresponding scene.
  scene       Visualize a specific scene.
```

#### Visualize scene

```shell
$ t4viz scene --help
Usage: t4viz scene [OPTIONS] DATA_ROOT

  Visualize a specific scene.

Options:
  -f, --future FLOAT Future time seconds.
  -o, --output PATH  Output directory to save recoding .rrd file.
  --no-show          Indicates whether not to show viewer.
  --help             Show this message and exit.
```

#### Visualize instance

```shell
$ t4viz instance --help
Usage: t4viz instance [OPTIONS] DATA_ROOT INSTANCE

  Visualize a particular instance in a corresponding scene

Options:
  -f, --future FLOAT Future time seconds.
  -o, --output PATH  Output directory to save recoding .rrd file.
  --no-show          Indicates whether not to show viewer.
  --help             Show this message and exit.
```

#### Visualize pointcloud

```shell
$ t4viz pointcloud --help
Usage: t4viz pointcloud [OPTIONS] DATA_ROOT

  Visualize pointcloud in a corresponding scene.

Options:
  -d, --distortion       Indicates whether not to ignore camera distortion.
  -o, --output PATH  Output directory to save recoding .rrd file.
  --no-show          Indicates whether not to show viewer.
  --help             Show this message and exit.
```