### PR TITLE
fix: expect mask shape with (width, height) order

### DIFF
--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -44,7 +44,7 @@ class RLEMask:
         """
         counts = base64.b64decode(self.counts)
         data = {"counts": counts, "size": self.size}
-        return cocomask.decode(data)
+        return cocomask.decode(data).T
 
 
 @define(slots=False)

--- a/t4_devkit/viewer/rendering_data/segmentation.py
+++ b/t4_devkit/viewer/rendering_data/segmentation.py
@@ -48,8 +48,7 @@ class SegmentationData2D:
         else:
             if self.size != mask.shape:
                 raise ValueError(
-                    f"All masks must be the same size. Expected: {self.size}, "
-                    f"but got {mask.shape}."
+                    f"All masks must be the same size. Expected: {self.size}, but got {mask.shape}."
                 )
         self.masks.append(mask)
         self.class_ids.append(class_id)
@@ -66,7 +65,7 @@ class SegmentationData2D:
         TODO:
             Add support of instance segmentation.
         """
-        image = np.full(self.size, -1, dtype=np.int64)
+        image = np.zeros(self.size, dtype=np.uint8)
 
         for mask, class_id in zip(self.masks, self.class_ids, strict=True):
             image[mask == 1] = class_id


### PR DESCRIPTION
## What

As of https://github.com/tier4/tier4_perception_dataset/pull/197, the shape of segmentation mask in T4 dataset is expected as (width, height) order, not (height, width) order.

This PR updates to transform loaded mask in (width, height) to (height, width) order for rendering.