### PR TITLE
fix: avoid error during rendering segmentation image

### DIFF
--- a/t4_devkit/viewer/rendering_data/segmentation.py
+++ b/t4_devkit/viewer/rendering_data/segmentation.py
@@ -48,8 +48,7 @@ class SegmentationData2D:
         else:
             if self.size != mask.shape:
                 raise ValueError(
-                    f"All masks must be the same size. Expected: {self.size}, "
-                    f"but got {mask.shape}."
+                    f"All masks must be the same size. Expected: {self.size}, but got {mask.shape}."
                 )
         self.masks.append(mask)
         self.class_ids.append(class_id)
@@ -66,7 +65,7 @@ class SegmentationData2D:
         TODO:
             Add support of instance segmentation.
         """
-        image = np.full(self.size, -1, dtype=np.int64)
+        image = np.zeros(self.size, dtype=np.uint8)
 
         for mask, class_id in zip(self.masks, self.class_ids, strict=True):
             image[mask == 1] = class_id


### PR DESCRIPTION
## What

This PR fixes runtime error during rendering segmentation images as follows:

```shell
[2025-02-11T05:27:45Z ERROR wgpu_core::device::global] Device::create_texture error: Dimension Y is zero
[2025-02-11T05:27:45Z ERROR wgpu_core::device::global] Texture::create_view(Id(134,36,vk)) error: TextureId Id(134,36,vk) is invalid
[2025-02-11T05:27:45Z ERROR re_space_view_spatial::visualizers::utilities::textured_rect] Failed to create texture for "/map/base_link/CAM_BACK/segmentation": Failed to create class_id_colormap.
[2025-02-11T05:27:45Z ERROR wgpu_core::device::global] Device::create_texture error: Dimension Y is zero
[2025-02-11T05:27:45Z ERROR wgpu_core::device::global] Texture::create_view(Id(89,61,vk)) error: TextureId Id(89,61,vk) is invalid
[2025-02-11T05:27:45Z WARN  re_renderer::error_handling::wgpu_core_error] unknown error cause cause=InvalidDimension(Zero(Y))
[2025-02-11T05:27:45Z ERROR re_renderer::error_handling::error_tracker] Wgpu validation error 1976: Validation Error
    
    Caused by:
      In Device::create_texture
        Dimension Y is zero
    
[2025-02-11T05:27:45Z ERROR re_space_view_spatial::visualizers::utilities::textured_rect] Failed to create texture for "/map/base_link/CAM_BACK_LEFT/segmentation": Failed to create class_id_colormap.
```

As of this PR, no error is raised.