### PR TITLE
fix: resolve instance visualization doesn't work

### DIFF
--- a/t4_devkit/viewer/rendering_data/box.py
+++ b/t4_devkit/viewer/rendering_data/box.py
@@ -100,7 +100,7 @@ class BoxData3D:
             self.velocities.append(box.velocity)
 
         if box.uuid is not None:
-            self.uuids.append(box.uuid[:6])
+            self.uuids.append(box.uuid)
 
         if box.future is not None:
             self.future.append(box.future)
@@ -147,6 +147,7 @@ class BoxData3D:
             rotations=self.rotations,
             labels=labels,
             class_ids=self.class_ids,
+            show_labels=False,
         )
 
     def as_arrows3d(self) -> rr.Arrows3D:
@@ -226,7 +227,7 @@ class BoxData2D:
         self.class_ids.append(self.label2id[box.semantic_label.name])
 
         if box.uuid is not None:
-            self.uuids.append(box.uuid[:6])
+            self.uuids.append(box.uuid)
 
     def _append_with_elements(self, roi: RoiType, class_id: int, uuid: str | None = None) -> None:
         self.rois.append(roi)
@@ -248,4 +249,5 @@ class BoxData2D:
             array_format=rr.Box2DFormat.XYXY,
             labels=labels,
             class_ids=self.class_ids,
+            show_labels=False,
         )

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -245,8 +245,7 @@ class RerunViewer:
         for box in boxes:
             if box.frame_id not in box_data:
                 box_data[box.frame_id] = BoxData3D(label2id=self.label2id)
-            else:
-                box_data[box.frame_id].append(box)
+            box_data[box.frame_id].append(box)
 
         for frame_id, data in box_data.items():
             # record boxes 3d
@@ -371,8 +370,7 @@ class RerunViewer:
         for box in boxes:
             if box.frame_id not in box_data:
                 box_data[box.frame_id] = BoxData2D(label2id=self.label2id)
-            else:
-                box_data[box.frame_id].append(box)
+            box_data[box.frame_id].append(box)
 
         for frame_id, data in box_data.items():
             rr.log(


### PR DESCRIPTION
## What

This PR fixes the issue that instance visualization doesn't visualize instance boxes.
As a tiny change, this PR also contains the change that making disable to visualize uuids on the 3D space.