### PR TITLE
feat: add timestamps attribute to trajectory dataclass

### DIFF
--- a/t4_devkit/dataclass/trajectory.py
+++ b/t4_devkit/dataclass/trajectory.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Generator
 
 import numpy as np
-from attrs import Attribute, define, field
+from attrs import define, field
 
 if TYPE_CHECKING:
-    from t4_devkit.typing import RotationType, TrajectoryType, TranslationType
+    from t4_devkit.typing import NDArrayFloat, NDArrayInt, RotationType, TranslationType
 
-__all__ = ["Trajectory", "to_trajectories"]
+__all__ = ["Past", "Future"]
 
 
 @define
@@ -21,52 +21,91 @@ class Trajectory:
 
     Examples:
         >>> trajectory = Trajectory(
-        ...     waypoints=[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]],
-        ...     confidence=1.0,
+        ...     timestamps=[1.0, 2.0]
+        ...     confidences=[1.0],
+        ...     waypoints=[[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]],
         ... )
-        # Get the number of waypoints.
+        # Get the number of modes.
         >>> len(trajectory)
-        2
-        # Access the shape of waypoints matrix: (N, 3).
+        1
+        # Access the shape of waypoints matrix: (M, T, 3).
         >>> trajectory.shape
-        (2, 3)
-        # Access each point as subscriptable.
-        >>> trajectory[0]
+        (1, 2, 3)
+        # Access waypoints as subscriptable.
+        >>> trajectory[0] # for mode0
+        array([[1., 1., 1.],
+               [2., 2., 2.]])
+        >>> trajectory[0, 0] # point0 at mode0
         array([1., 1., 1.])
-        # Access each point as iterable.
-        >>> for point in trajectory:
-        ...     print(point)
+        # Access confidence and waypoints for each mode as iterable.
+        >>> for i, (confidence, waypoints) in trajectory:
+        ...     print(f"Mode{i}: {confidence}, {waypoints}")
         ...
-        [1. 1. 1.]
-        [2. 2. 2.]
+        Mode0: 1.0, [[1. 1. 1.] [2. 2. 2.]]
     """
 
-    waypoints: TrajectoryType = field(converter=np.array)
-    confidence: float = field(default=1.0)
+    timestamps: NDArrayInt = field(converter=np.array)
+    confidences: NDArrayFloat = field(converter=np.array)
+    waypoints: NDArrayFloat = field(converter=np.array)
 
-    @waypoints.validator
-    def _check_dims(self, attribute: Attribute, value: TrajectoryType) -> None:
-        if value.ndim != 2:
-            raise ValueError(f"{attribute.name} must be 2D matrix.")
+    def __attrs_post_init__(self) -> None:
+        self._check_dims()
 
-        if value.shape[1] != 3:
-            raise ValueError(f"{attribute.name} dimension must be 3.")
+    def _check_dims(self) -> None:
+        if self.waypoints.ndim != 3:
+            raise ValueError(f"`waypoints` must be [M, T, D] tensor, but got {self.waypoints.ndim}")
+
+        if self.waypoints.shape[2] != 3:
+            raise ValueError(f"`waypoints` dimension must be 3, but got {self.waypoints.shape[2]}")
+
+        # check timestamp length between timestamps and waypoints
+        if len(self.timestamps) != self.waypoints.shape[1]:
+            raise ValueError(
+                "Timestamp length must be the same between `timestamps` and `waypoints`, "
+                f"but got timestamps={len(self.timestamps)} and waypoints={self.waypoints.shape[1]}"
+            )
+
+        # check mode length between waypoints and confidences
+        if self.waypoints.shape[0] != len(self.confidences):
+            raise ValueError(
+                "Mode length must be the same between `waypoints` and `confidences`, "
+                f"but got waypoints={self.waypoints.shape[0]} and confidences={len(self.confidences)}"
+            )
 
     def __len__(self) -> int:
+        """Return the number of modes."""
         return len(self.waypoints)
 
-    def __getitem__(self, index: int) -> TranslationType:
+    def __getitem__(self, index: int | slice[int]) -> NDArrayFloat:
         return self.waypoints[index]
 
-    def __iter__(self) -> Generator[TrajectoryType]:
-        yield from self.waypoints
+    def __iter__(self) -> Generator[tuple[float, NDArrayFloat]]:
+        yield from zip(self.confidences, self.waypoints, strict=True)
+
+    @property
+    def num_mode(self) -> int:
+        """Return the number of trajectory modes.
+
+        Returns:
+            int: The number of trajectory modes.
+        """
+        return self.shape[0]
+
+    @property
+    def num_timestamp(self) -> int:
+        """Return the number of timestamps.
+
+        Returns:
+            int: The number of timestamps.
+        """
+        return self.shape[1]
 
     @property
     def shape(self) -> tuple[int, ...]:
         """Return the shape of the waypoints matrix.
 
         Returns:
-            Shape of the matrix (N, 3).
+            Shape of the matrix (M, T, D).
         """
         return self.waypoints.shape
 
@@ -88,20 +127,21 @@ class Trajectory:
         self.waypoints = np.dot(self.waypoints, q.rotation_matrix.T)
 
 
-def to_trajectories(
-    waypoints: list[TrajectoryType],
-    confidences: list[float],
-) -> list[Trajectory]:
-    """Convert a list of waypoints and confidences to a list of `Trajectory`s for each mode.
+@define
+class Past(Trajectory):
+    """Represent the past trajectory features.
 
-    Args:
-        waypoints (list[TrajectoryType]): List of waypoints for each mode.
-        confidences (list[float]): List of confidences for each mode.
+    Note that the expected shape of waypoints is (1, T, D)."""
 
-    Returns:
-        List of `Trajectory`s for each mode.
-    """
-    return [
-        Trajectory(points, confidence)
-        for points, confidence in zip(waypoints, confidences, strict=True)
-    ]
+    def _check_dims(self) -> None:
+        super()._check_dims()
+
+        if self.num_mode != 1:
+            raise ValueError(f"The number of modes for past must be 1, but got {self.num_mode}")
+
+
+@define
+class Future(Trajectory):
+    """Represent the future trajectory features.
+
+    Note that the expected shape of waypoints is (M, T, D)."""

--- a/t4_devkit/helper/timeseries.py
+++ b/t4_devkit/helper/timeseries.py
@@ -35,7 +35,7 @@ class TimeseriesHelper:
         instance_token: str,
         sample_token: str,
         seconds: float,
-    ) -> list[SampleAnnotation]:
+    ) -> tuple[list[int], list[SampleAnnotation]]:
         """Return a list of sample annotations until the specified seconds.
 
         If `seconds>=0` explores future, otherwise past.
@@ -46,11 +46,12 @@ class TimeseriesHelper:
             seconds (float): Time seconds until. If `>=0` explore future, otherwise past.
 
         Returns:
-            List of sample annotation records of the specified instance.
+            List of timestamps and associated sample annotation records of the specified instance.
         """
         start_sample: Sample = self._t4.get("sample", sample_token)
 
-        outputs: list[SampleAnnotation] = []
+        timestamps: list[int] = []
+        anns: list[SampleAnnotation] = []
         is_successor = seconds >= 0
         current_sample_token = start_sample.next if is_successor else start_sample.prev
         while current_sample_token != "":
@@ -63,18 +64,19 @@ class TimeseriesHelper:
                 (current_sample_token, instance_token)
             )
             if ann_token is not None:
-                outputs.append(self._t4.get("sample_annotation", ann_token))
+                timestamps.append(current_sample.timestamp)
+                anns.append(self._t4.get("sample_annotation", ann_token))
 
             current_sample_token = current_sample.next if is_successor else current_sample.prev
 
-        return outputs
+        return timestamps, anns
 
     def get_object_anns_until(
         self,
         instance_token: str,
         sample_data_token: str,
         seconds: float,
-    ) -> list[ObjectAnn]:
+    ) -> tuple[list[int], list[ObjectAnn]]:
         """Return a list of object anns until the specified seconds.
 
         If `seconds>=0` explores future, otherwise past.
@@ -85,11 +87,12 @@ class TimeseriesHelper:
             seconds (float): Time seconds until. If `>=0` explore future, otherwise past.
 
         Returns:
-            List of object annotation records of the specified instance.
+            List of timestamps and associated object annotation records of the specified instance.
         """
         start_sample_data: SampleData = self._t4.get("sample_data", sample_data_token)
 
-        outputs: list[ObjectAnn] = []
+        timestamps: list[int] = []
+        anns: list[ObjectAnn] = []
         is_successor = seconds >= 0
         current_sample_data_token = (
             start_sample_data.next if is_successor else start_sample_data.prev
@@ -106,10 +109,11 @@ class TimeseriesHelper:
                 (current_sample_data_token, instance_token)
             )
             if ann_token is not None:
-                outputs.append(self._t4.get("object_ann", ann_token))
+                timestamps.append(current_sample_data.timestamp)
+                anns.append(self._t4.get("object_ann", ann_token))
 
             current_sample_data_token = (
                 current_sample_data.next if is_successor else current_sample_data.prev
             )
 
-        return outputs
+        return timestamps, anns

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -446,13 +446,13 @@ class Tier4:
 
         if future_seconds > 0.0:
             # NOTE: Future trajectory is map coordinate frame
-            anns: list[SampleAnnotation] = self._timeseries_helper.get_sample_annotations_util(
+            timestamps, anns = self._timeseries_helper.get_sample_annotations_util(
                 ann.instance_token, ann.sample_token, future_seconds
             )
             if len(anns) == 0:
                 return box
             waypoints = [ann.translation for ann in anns]
-            return box.with_future(waypoints=[waypoints], confidences=[1.0])
+            return box.with_future(timestamps=timestamps, confidences=[1.0], waypoints=[waypoints])
         else:
             return box
 

--- a/t4_devkit/viewer/rendering_data/box.py
+++ b/t4_devkit/viewer/rendering_data/box.py
@@ -8,7 +8,7 @@ import rerun.components as rrc
 from attrs import define, field
 
 if TYPE_CHECKING:
-    from t4_devkit.dataclass import Box2D, Box3D, Trajectory
+    from t4_devkit.dataclass import Box2D, Box3D, Future
     from t4_devkit.typing import (
         RoiType,
         RotationType,
@@ -42,7 +42,7 @@ class BoxData3D:
     class_ids: list[int] = field(init=False, factory=list)
     uuids: list[str] = field(init=False, factory=list)
     velocities: list[VelocityType] = field(init=False, factory=list)
-    future: list[list[Trajectory]] = field(init=False, factory=list)
+    future: list[Future] = field(init=False, factory=list)
 
     @overload
     def append(self, box: Box3D) -> None:
@@ -62,7 +62,7 @@ class BoxData3D:
         class_id: int,
         uuid: str | None = None,
         velocity: VelocityType | None = None,
-        future: list[Trajectory] | None = None,
+        future: Future | None = None,
     ) -> None:
         """Append a 3D box data with its elements.
 
@@ -73,7 +73,7 @@ class BoxData3D:
             class_id (int): Class ID.
             uuid (str | None, optional): Unique identifier.
             velocity (VelocityType | None, optional): Box velocity.
-            future (list[Trajectory] | None, optional): Future trajectory.
+            future (Future | None, optional): Future trajectory.
         """
         pass
 
@@ -114,7 +114,7 @@ class BoxData3D:
         class_id: int,
         velocity: VelocityType | None = None,
         uuid: str | None = None,
-        future: list[Trajectory] | None = None,
+        future: Future | None = None,
     ) -> None:
         self.centers.append(center)
 
@@ -172,9 +172,9 @@ class BoxData3D:
         """
         stripes = []
         class_ids = []
-        for class_id, modes in zip(self.class_ids, self.future):
-            class_ids += [class_id] * len(modes)
-            stripes += [x.waypoints for x in modes]
+        for class_id, future in zip(self.class_ids, self.future):
+            class_ids += [class_id] * future.num_mode
+            stripes += [waypoints for _, waypoints in future]
         return rr.LineStrips3D(strips=stripes, class_ids=class_ids)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,11 @@ from pyquaternion import Quaternion
 from t4_devkit.dataclass import (
     Box2D,
     Box3D,
+    Future,
     HomogeneousMatrix,
     SemanticLabel,
     Shape,
     ShapeType,
-    Trajectory,
     TransformBuffer,
 )
 
@@ -44,6 +44,8 @@ def dummy_box3d() -> Box3D:
         confidence=1.0,
         uuid="car3d_0",
     ).with_future(
+        timestamps=[101, 102, 103, 104],
+        confidences=[1.0, 0.5],
         waypoints=[
             np.array(
                 [
@@ -62,7 +64,6 @@ def dummy_box3d() -> Box3D:
                 ]
             ),
         ],
-        confidences=[1.0, 0.5],
     )
 
 
@@ -85,6 +86,8 @@ def dummy_box3ds() -> list[Box3D]:
             confidence=1.0,
             uuid="car3d_1",
         ).with_future(
+            timestamps=[101, 102, 103, 104],
+            confidences=[1.0],
             waypoints=[
                 np.array(
                     [
@@ -95,7 +98,6 @@ def dummy_box3ds() -> list[Box3D]:
                     ]
                 ),
             ],
-            confidences=[1.0],
         ),
         Box3D(
             unix_time=100,
@@ -108,6 +110,8 @@ def dummy_box3ds() -> list[Box3D]:
             confidence=1.0,
             uuid="bicycle3d_1",
         ).with_future(
+            timestamps=[101, 102, 103, 104],
+            confidences=[1.0, 0.5],
             waypoints=[
                 np.array(
                     [
@@ -126,7 +130,6 @@ def dummy_box3ds() -> list[Box3D]:
                     ]
                 ),
             ],
-            confidences=[1.0, 0.5],
         ),
         Box3D(
             unix_time=100,
@@ -139,6 +142,8 @@ def dummy_box3ds() -> list[Box3D]:
             confidence=1.0,
             uuid="pedestrian3d_1",
         ).with_future(
+            timestamps=[101, 102, 103, 104],
+            confidences=[1.0, 0.5, 0.2],
             waypoints=[
                 np.array(
                     [
@@ -165,7 +170,6 @@ def dummy_box3ds() -> list[Box3D]:
                     ]
                 ),
             ],
-            confidences=[1.0, 0.5, 0.2],
         ),
     ]
 
@@ -223,16 +227,17 @@ def dummy_box2ds() -> list[Box2D]:
 
 
 @pytest.fixture(scope="function")
-def dummy_trajectory() -> Trajectory:
-    """Return a dummy trajectory.
+def dummy_future() -> Future:
+    """Return a dummy future trajectory.
 
     Returns:
-        A trajectory.
+        A future trajectory.
     """
     # list item is converted to NDArray internally
-    return Trajectory(
-        waypoints=[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]],
-        confidence=1.0,
+    return Future(
+        timestamps=[101, 102],
+        confidences=[1.0],
+        waypoints=[[[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]]],
     )
 
 

--- a/tests/dataclass/test_trajectory.py
+++ b/tests/dataclass/test_trajectory.py
@@ -1,69 +1,79 @@
+from __future__ import annotations
+
 import numpy as np
 import pytest
 from pyquaternion import Quaternion
 
-from t4_devkit.dataclass.trajectory import to_trajectories
+from t4_devkit.dataclass.trajectory import Future
 
 
-def test_trajectory(dummy_trajectory) -> None:
-    """Test `Trajectory` class including its initialization and methods."""
+def test_future_trajectory(dummy_future: Future) -> None:
+    """Test `Future` class including its initialization and methods."""
 
-    assert dummy_trajectory.confidence == 1.0
+    assert np.allclose(dummy_future.confidences, [1.0])
 
-    # test __len__()
-    assert len(dummy_trajectory) == 2
+    # test __len__() -> the number of modes
+    assert len(dummy_future) == 1
 
     # test __getitem__()
-    assert np.allclose(dummy_trajectory[0], (1.0, 1.0, 1.0))
-    assert np.allclose(dummy_trajectory[1], (2.0, 2.0, 2.0))
+    # index
+    assert np.allclose(dummy_future[0], [(1.0, 1.0, 1.0), (2.0, 2.0, 2.0)])
+    # slice
+    assert np.allclose(dummy_future[:, 0], (1.0, 1.0, 1.0))
+    assert np.allclose(dummy_future[:, 1], (2.0, 2.0, 2.0))
 
     # test __iter__()
-    for point in dummy_trajectory:
-        assert isinstance(point, np.ndarray)
-        assert point.shape == (3,)
+    for confidence, waypoints in dummy_future:
+        assert isinstance(waypoints, np.ndarray)
+        assert waypoints.shape == (2, 3)
+        assert isinstance(confidence, float)
 
     # test shape property
-    assert dummy_trajectory.shape == (2, 3)
+    assert dummy_future.num_mode == 1
+    assert dummy_future.num_timestamp == 2
+    assert dummy_future.shape == (1, 2, 3)
 
 
-def test_trajectory_translate(dummy_trajectory) -> None:
+def test_trajectory_translate(dummy_future: Future) -> None:
     """Test `translate` methods of `Trajectory` class."""
-    dummy_trajectory.translate(x=(1.0, 2.0, 3.0))
+    dummy_future.translate(x=(1.0, 2.0, 3.0))
 
-    assert np.allclose(dummy_trajectory[0], (2.0, 3.0, 4.0))
-    assert np.allclose(dummy_trajectory[1], (3.0, 4.0, 5.0))
+    assert np.allclose(dummy_future[0, 0], (2.0, 3.0, 4.0))
+    assert np.allclose(dummy_future[0, 1], (3.0, 4.0, 5.0))
 
 
-def test_trajectory_rotate(dummy_trajectory) -> None:
+def test_trajectory_rotate(dummy_future: Future) -> None:
     """Test `rotate` methods of `Trajectory` class."""
     # +90 [deg]
-    dummy_trajectory.rotate(q=Quaternion([0.7071067811865475, 0.0, 0.0, -0.7071067811865475]))
+    dummy_future.rotate(q=Quaternion([0.7071067811865475, 0.0, 0.0, -0.7071067811865475]))
 
-    assert np.allclose(dummy_trajectory[0], (1.0, -1.0, 1.0))
-    assert np.allclose(dummy_trajectory[1], (2.0, -2.0, 2.0))
+    assert np.allclose(dummy_future[0, 0], (1.0, -1.0, 1.0))
+    assert np.allclose(dummy_future[0, 1], (2.0, -2.0, 2.0))
 
 
-def test_to_trajectories() -> None:
+def test_to_future() -> None:
     """Test `to_trajectories` function including its valid and invalid cases."""
     # valid case
-    trajectories = to_trajectories(
-        waypoints=[
-            [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode0
-            [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode1
-        ],
+    future = Future(
+        timestamps=[101, 102, 103],
         confidences=[
             1.0,  # mode0
             2.0,  # mode1
         ],
+        waypoints=[
+            [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode0
+            [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode1
+        ],
     )
-    assert len(trajectories) == 2
+    assert len(future) == 2
 
     # invalid case: different element length
     with pytest.raises(ValueError):
-        _ = to_trajectories(
+        _ = Future(
+            timestamps=[101, 102, 103],
+            confidences=[1.0],  # mode0
             waypoints=[
-                [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],
-                [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],
+                [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode0
+                [[1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]],  # mode1
             ],
-            confidences=[1.0],
         )


### PR DESCRIPTION
## What

This PR introduces `timestamps` attribute to the `Trajectory` dataclass.
Moreover, this PR includes separating `Trajectory` class into `Future` and `Past` classes.

Note that `Future` class consists of the `waypoints` in the shape of `(M, Tf, D), where `M` is the number of modes, `Tf` is the number of future timestamps.
However, `Past` class consists of the waypoints in the shape of `(1, Tp, D)`, where `Tp` is the number of past timestamps.