### PR TITLE
feat: replace serialize functions

### DIFF
--- a/docs/tutorials/customize.md
+++ b/docs/tutorials/customize.md
@@ -5,7 +5,8 @@
 You can crate a schema containing the specified table data with a new token using `new(...)` methods.
 
 ```python title="generate_attribute.py"
-from t4_devkit.schema import Attribute, serialize_schema
+from t4_devkit.schema import Attribute
+from t4_devkit.common.serialize import serialize_dataclass
 
 # schema data except of the unique identifier token
 data = {
@@ -16,7 +17,7 @@ data = {
 attr1 = Attribute.new(data)
 
 # Also, it allows us to create a copy of the existing table data with a new token
-serialized = serialize_schema(attr1)
+serialized = serialize_dataclass(attr1)
 attr2 = Attribute.new(serialized)
 
 assert attr1.token != attr2.token

--- a/t4_devkit/common/serialize.py
+++ b/t4_devkit/common/serialize.py
@@ -8,6 +8,18 @@ from attrs import asdict, fields, filters
 from pyquaternion import Quaternion
 
 
+def serialize_dataclasses(data: list[Any]) -> list[dict]:
+    """Serialize list of attrs' dataclasses into list of dict.
+
+    Args:
+        data (list[Any]): List of attrs' dataclasses.
+
+    Returns:
+        Serialized list of dict data.
+    """
+    return [serialize_dataclass(d) for d in data]
+
+
 def serialize_dataclass(data: Any) -> dict[str, Any]:
     """Serialize attrs' dataclasses into dict.
 
@@ -17,7 +29,7 @@ def serialize_dataclass(data: Any) -> dict[str, Any]:
         data (Any): Dataclass object.
 
     Returns:
-        dict[str, Any]: Serialized dict.
+        Serialized dict.
     """
     excludes = filters.exclude(*[a for a in fields(data.__class__) if not a.init])
     return asdict(data, filter=excludes, value_serializer=_value_serializer)

--- a/t4_devkit/schema/serialize.py
+++ b/t4_devkit/schema/serialize.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from t4_devkit.common.serialize import serialize_dataclass
+from typing_extensions import deprecated
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
 
 if TYPE_CHECKING:
     from .tables import SchemaTable
@@ -11,8 +13,12 @@ if TYPE_CHECKING:
 __all__ = ("serialize_schemas", "serialize_schema")
 
 
+@deprecated("`serialize_schemas()` is deprecated. Please use `serialize_dataclasses()` instead.")
 def serialize_schemas(data: list[SchemaTable]) -> list[dict]:
     """Serialize a list of schema dataclasses into list of dict.
+
+    Deprecated:
+        This function is deprecated. Please use `serialize_dataclasses()` instead.
 
     Args:
         data (list[SchemaTable]): List of schema dataclasses.
@@ -20,11 +26,15 @@ def serialize_schemas(data: list[SchemaTable]) -> list[dict]:
     Returns:
         Serialized list of dict data.
     """
-    return [serialize_schema(d) for d in data]
+    return serialize_dataclasses(data)
 
 
+@deprecated("`serialize_schema()` is deprecated. Please use `serialize_dataclass()` instead.")
 def serialize_schema(data: SchemaTable) -> dict:
     """Serialize a schema dataclass into dict.
+
+    Deprecated:
+        This function is deprecated. Please use `serialize_dataclass()` instead.
 
     Args:
         data (SchemaTable): Schema dataclass.

--- a/tests/schema/tables/test_attribute_table.py
+++ b/tests/schema/tables/test_attribute_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Attribute, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Attribute
 
 
 def test_attribute_json(attribute_json) -> None:
     """Test loading attribute from a json file."""
     schemas = Attribute.from_json(attribute_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_attribute(attribute_dict) -> None:
     """Test loading attribute from a dictionary."""
     schema = Attribute.from_dict(attribute_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == attribute_dict
 
 

--- a/tests/schema/tables/test_calibrated_sensor_table.py
+++ b/tests/schema/tables/test_calibrated_sensor_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import CalibratedSensor, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import CalibratedSensor
 
 
 def test_calibrated_sensor_json(calibrated_sensor_json) -> None:
     """Test loading calibrated sensor from a json file."""
     schemas = CalibratedSensor.from_json(calibrated_sensor_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_calibrated_sensor(calibrated_sensor_dict) -> None:
     """Test loading calibrated sensor from a dictionary."""
     schema = CalibratedSensor.from_dict(calibrated_sensor_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == calibrated_sensor_dict
 
 

--- a/tests/schema/tables/test_category_table.py
+++ b/tests/schema/tables/test_category_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Category, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Category
 
 
 def test_category_json(category_json) -> None:
     """Test loading category from a json file."""
     schemas = Category.from_json(category_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_category(category_dict) -> None:
     """Test loading sample data from a dictionary."""
     schema = Category.from_dict(category_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == category_dict
 
 

--- a/tests/schema/tables/test_ego_pose_table.py
+++ b/tests/schema/tables/test_ego_pose_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import EgoPose, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import EgoPose
 
 
 def test_ego_pose_json(ego_pose_json) -> None:
     """Test loading ego pose from a json file."""
     schemas = EgoPose.from_json(ego_pose_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_ego_pose(ego_pose_dict) -> None:
     """Test loading ego pose from a dictionary."""
     schema = EgoPose.from_dict(ego_pose_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == ego_pose_dict
 
 

--- a/tests/schema/tables/test_instance_table.py
+++ b/tests/schema/tables/test_instance_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Instance, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Instance
 
 
 def test_instance_json(instance_json) -> None:
     """Test loading instance from a json file."""
     schemas = Instance.from_json(instance_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_instance(instance_dict) -> None:
     """Test loading instance from a dictionary."""
     schema = Instance.from_dict(instance_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == instance_dict
 
 

--- a/tests/schema/tables/test_log_table.py
+++ b/tests/schema/tables/test_log_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Log, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Log
 
 
 def test_log_json(log_json) -> None:
     """Test loading log from a json file."""
     schemas = Log.from_json(log_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_log(log_dict) -> None:
     """Test loading log from a dictionary."""
     schema = Log.from_dict(log_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == log_dict
 
 

--- a/tests/schema/tables/test_map_table.py
+++ b/tests/schema/tables/test_map_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Map, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Map
 
 
 def test_map_json(map_json) -> None:
     """Test loading map from a json file."""
     schemas = Map.from_json(map_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_map(map_dict) -> None:
     """Test loading map from a dictionary."""
     schema = Map.from_dict(map_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == map_dict
 
 

--- a/tests/schema/tables/test_object_ann_table.py
+++ b/tests/schema/tables/test_object_ann_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import ObjectAnn, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import ObjectAnn
 
 
 def test_object_ann_json(object_ann_json) -> None:
     """Test loading object ann from a json file."""
     schemas = ObjectAnn.from_json(object_ann_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_object_ann(object_ann_dict) -> None:
     """Test loading object ann from a dictionary."""
     schema = ObjectAnn.from_dict(object_ann_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == object_ann_dict
 
 

--- a/tests/schema/tables/test_sample_annotation_table.py
+++ b/tests/schema/tables/test_sample_annotation_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import SampleAnnotation, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import SampleAnnotation
 
 
 def test_sample_annotation_json(sample_annotation_json) -> None:
     """Test loading sample annotation from a json file."""
     schemas = SampleAnnotation.from_json(sample_annotation_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_sample_annotation(sample_annotation_dict) -> None:
     """Test loading sample annotation from a dictionary."""
     schema = SampleAnnotation.from_dict(sample_annotation_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == sample_annotation_dict
 
 

--- a/tests/schema/tables/test_sample_data_table.py
+++ b/tests/schema/tables/test_sample_data_table.py
@@ -1,4 +1,7 @@
-from t4_devkit.schema import FileFormat, SampleData, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import FileFormat, SampleData
 
 
 def test_fileformat() -> None:
@@ -27,14 +30,14 @@ def test_fileformat() -> None:
 def test_sample_data_json(sample_data_json) -> None:
     """Test loading sample data from a json file."""
     schemas = SampleData.from_json(sample_data_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_sample_data(sample_data_dict) -> None:
     """Test loading sample data from a dictionary."""
     schema = SampleData.from_dict(sample_data_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == sample_data_dict
 
 

--- a/tests/schema/tables/test_sample_table.py
+++ b/tests/schema/tables/test_sample_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import Sample, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Sample
 
 
 def test_sample_json(sample_json) -> None:
     """Test loading sample from a json file."""
     schemas = Sample.from_json(sample_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_sample(sample_dict) -> None:
     """Test loading sample from a dictionary."""
     schema = Sample.from_dict(sample_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == sample_dict
 
 

--- a/tests/schema/tables/test_sensor_table.py
+++ b/tests/schema/tables/test_sensor_table.py
@@ -1,4 +1,7 @@
-from t4_devkit.schema import Sensor, SensorModality, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Sensor, SensorModality
 
 
 def test_sensor_modality() -> None:
@@ -18,14 +21,14 @@ def test_sensor_modality() -> None:
 def test_sensor_json(sensor_json) -> None:
     """Test loading sensor from a json file."""
     schemas = Sensor.from_json(sensor_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_sensor(sensor_dict) -> None:
     """Test loading sensor from a dictionary."""
     schema = Sensor.from_dict(sensor_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == sensor_dict
 
 

--- a/tests/schema/tables/test_surface_ann_table.py
+++ b/tests/schema/tables/test_surface_ann_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import SurfaceAnn, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import SurfaceAnn
 
 
 def test_surface_ann_json(surface_ann_json) -> None:
     """Test loading surface ann from a json file."""
     schemas = SurfaceAnn.from_json(surface_ann_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_surface_ann(surface_ann_dict) -> None:
     """Test loading surface ann from a dictionary."""
     schema = SurfaceAnn.from_dict(surface_ann_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == surface_ann_dict
 
 

--- a/tests/schema/tables/test_vehicle_state_table.py
+++ b/tests/schema/tables/test_vehicle_state_table.py
@@ -1,17 +1,20 @@
-from t4_devkit.schema import VehicleState, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import VehicleState
 
 
 def test_vehicle_state_json(vehicle_state_json) -> None:
     """Test loading vehicle state from a json file."""
     schemas = VehicleState.from_json(vehicle_state_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_vehicle_state(vehicle_state_dict) -> None:
     """Test loading vehicle state from a dictionary."""
     schema = VehicleState.from_dict(vehicle_state_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == vehicle_state_dict
 
 

--- a/tests/schema/tables/test_visibility_table.py
+++ b/tests/schema/tables/test_visibility_table.py
@@ -1,4 +1,7 @@
-from t4_devkit.schema import Visibility, VisibilityLevel, serialize_schema, serialize_schemas
+from __future__ import annotations
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import Visibility, VisibilityLevel
 
 
 def test_visibility_level() -> None:
@@ -29,14 +32,14 @@ def test_visibility_level_deprecated() -> None:
 def test_visibility_json(visibility_json) -> None:
     """Test loading visibility from a json file."""
     schemas = Visibility.from_json(visibility_json)
-    serialized = serialize_schemas(schemas)
+    serialized = serialize_dataclasses(schemas)
     assert isinstance(serialized, list)
 
 
 def test_visibility(visibility_dict) -> None:
     """Test loading visibility from a dictionary."""
     schema = Visibility.from_dict(visibility_dict)
-    serialized = serialize_schema(schema)
+    serialized = serialize_dataclass(schema)
     assert serialized == visibility_dict
 
 


### PR DESCRIPTION
## What

This PR add new function called `serialize_dataclasses` which serializes list of attrs' dataclasses.

Also, this PR makes old functions, called `serialize_schema` and `serialize_schemas`, as **depreacated**.