### PR TITLE
test: add option whether to spawn viewer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,21 @@ if TYPE_CHECKING:
     from t4_devkit.typing import NDArrayFloat
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Add pytest options."""
+    parser.addoption(
+        "--spawn-viewer",
+        action="store_true",
+        help="Whether to spawn viewer for unit tests.",
+    )
+
+
+@pytest.fixture(scope="session")
+def spawn_viewer(pytestconfig) -> bool:
+    """Indicate whether to spawn viewer for unit tests."""
+    return pytestconfig.getoption("spawn_viewer")
+
+
 @pytest.fixture(scope="module")
 def label2id() -> dict[str, int]:
     return {"car": 0, "bicycle": 1, "pedestrian": 2}

--- a/tests/viewer/conftest.py
+++ b/tests/viewer/conftest.py
@@ -6,7 +6,7 @@ from t4_devkit.viewer import RerunViewer
 
 
 @pytest.fixture(scope="module")
-def dummy_viewer(label2id) -> RerunViewer:
+def dummy_viewer(spawn_viewer, label2id) -> RerunViewer:
     """Return a dummy viewer.
 
     Returns:
@@ -15,5 +15,5 @@ def dummy_viewer(label2id) -> RerunViewer:
     return RerunViewer(
         "test_viewer",
         cameras=["camera"],
-        spawn=False,  # set this to True for debugging
+        spawn=spawn_viewer,  # set this to True for debugging
     ).with_labels(label2id=label2id)


### PR DESCRIPTION
## What

This PR adds option for pytest whether to spawn viewer.

```shell
pytest --spawn-viewer
```

![Screenshot from 2025-05-08 23-31-51](https://github.com/user-attachments/assets/3ca1e636-505f-4f47-b250-db8aebfe6740)
