### PR TITLE
fix: invoke save recording before logging

### DIFF
--- a/docs/tutorials/cli.md
+++ b/docs/tutorials/cli.md
@@ -71,3 +71,13 @@ For options, run `t4viz pointcloud -h`.
 ```shell
 t4viz pointcloud <DATA_ROOT> [OPTIONS]
 ```
+
+#### Save Recording as `.rrd`
+
+You can save visualized recording with `-o --output` option as follows:
+
+```shell
+t4viz <COMMAND> <DATA_ROOT> -o <OUTPUT_DIR>
+```
+
+Note that if you specify `--output` option, viewer will not be spawned.

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -41,13 +41,12 @@ def scene(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
-    show: Annotated[bool, typer.Option(help="Indicates whether to show viewer.")] = True,
 ) -> None:
     _create_dir(output)
 
     t4 = Tier4("annotation", data_root, verbose=False)
     scene_token = t4.scene[0].token
-    t4.render_scene(scene_token, future_seconds=future, save_dir=output, show=show)
+    t4.render_scene(scene_token, future_seconds=future, save_dir=output)
 
 
 @cli.command("instance", help="Visualize a particular instance in the corresponding scene.")
@@ -72,12 +71,11 @@ def instance(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
-    show: Annotated[bool, typer.Option(help="Indicates whether to show viewer.")] = True,
 ) -> None:
     _create_dir(output)
 
     t4 = Tier4("annotation", data_root, verbose=False)
-    t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output, show=show)
+    t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output)
 
 
 @cli.command("pointcloud", help="Visualize pointcloud in the corresponding scene.")
@@ -101,7 +99,6 @@ def pointcloud(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
-    show: Annotated[bool, typer.Option(help="Indicates whether to show viewer.")] = True,
 ) -> None:
     _create_dir(output)
 
@@ -111,7 +108,6 @@ def pointcloud(
         scene_token,
         ignore_distortion=ignore_distortion,
         save_dir=output,
-        show=show,
     )
 
 

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -733,7 +733,6 @@ class Tier4:
         max_time_seconds: float = np.inf,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
-        show: bool = True,
     ) -> None:
         """Render specified scene.
 
@@ -742,14 +741,12 @@ class Tier4:
             max_time_seconds (float, optional): Max time length to be rendered [s].
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
-            show (bool, optional): Whether to spawn rendering viewer.
         """
         coroutine = self._rendering_helper.async_render_scene(
             scene_token=scene_token,
             max_time_seconds=max_time_seconds,
             future_seconds=future_seconds,
             save_dir=save_dir,
-            show=show,
         )
 
         asyncio.run(coroutine)
@@ -760,7 +757,6 @@ class Tier4:
         *,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
-        show: bool = True,
     ) -> None:
         """Render particular instance.
 
@@ -768,13 +764,11 @@ class Tier4:
             instance_token (str | Sequence[str]): Instance token(s).
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
-            show (bool, optional): Whether to spawn rendering viewer.
         """
         coroutine = self._rendering_helper.async_render_instance(
             instance_token=instance_token,
             future_seconds=future_seconds,
             save_dir=save_dir,
-            show=show,
         )
 
         asyncio.run(coroutine)
@@ -786,7 +780,6 @@ class Tier4:
         max_time_seconds: float = np.inf,
         ignore_distortion: bool = True,
         save_dir: str | None = None,
-        show: bool = True,
     ) -> None:
         """Render pointcloud on 3D and 2D view.
 
@@ -795,7 +788,6 @@ class Tier4:
             max_time_seconds (float, optional): Max time length to be rendered [s].
             save_dir (str | None, optional): Directory path to save the recording.
             ignore_distortion (bool, optional): Whether to ignore distortion parameters.
-            show (bool, optional): Whether to spawn rendering viewer.
 
         TODO:
             Add an option of rendering radar channels.
@@ -805,7 +797,6 @@ class Tier4:
             max_time_seconds=max_time_seconds,
             ignore_distortion=ignore_distortion,
             save_dir=save_dir,
-            show=show,
         )
 
         asyncio.run(coroutine)

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -74,7 +74,7 @@ class RerunViewer:
         *,
         cameras: Sequence[str] | None = None,
         with_3d: bool = True,
-        spawn: bool = True,
+        save_dir: str | None = None,
     ) -> None:
         """Construct a new object.
 
@@ -83,7 +83,8 @@ class RerunViewer:
             cameras (Sequence[str] | None, optional): Sequence of camera names.
                 If `None`, any 2D spaces will not be visualized.
             with_3d (bool, optional): Whether to render objects with the 3D space.
-            spawn (bool, optional): Whether to spawn the viewer.
+            save_dir (str | None, optional): Directory path to save the recording.
+                Viewer will be spawned if it is None, otherwise not.
 
         Examples:
             >>> from t4_devkit.viewer import RerunViewer
@@ -128,11 +129,15 @@ class RerunViewer:
         rr.init(
             application_id=self.app_id,
             recording_id=None,
-            spawn=spawn,
+            spawn=save_dir is None,
             default_enabled=True,
             strict=True,
             default_blueprint=self.blueprint,
         )
+
+        # NOTE: rr.save() must be invoked before logging
+        if save_dir is not None:
+            self._start_saving(save_dir=save_dir)
 
         rr.log(self.map_entity, rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
 
@@ -180,8 +185,11 @@ class RerunViewer:
         self.global_origin = lat_lon
         return self
 
-    def save(self, save_dir: str) -> None:
+    def _start_saving(self, save_dir: str) -> None:
         """Save recording result as `save_dir/{app_id}.rrd`.
+
+        Note:
+            This method must be called before any logging started.
 
         Args:
             save_dir (str): Directory path to save the result.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def spawn_viewer(pytestconfig) -> bool:
     return pytestconfig.getoption("spawn_viewer")
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="session")
 def label2id() -> dict[str, int]:
     return {"car": 0, "bicycle": 1, "pedestrian": 2}
 

--- a/tests/viewer/conftest.py
+++ b/tests/viewer/conftest.py
@@ -5,15 +5,17 @@ import pytest
 from t4_devkit.viewer import RerunViewer
 
 
-@pytest.fixture(scope="module")
-def dummy_viewer(spawn_viewer, label2id) -> RerunViewer:
+@pytest.fixture(scope="session")
+def dummy_viewer(tmpdir_factory, spawn_viewer, label2id) -> RerunViewer:
     """Return a dummy viewer.
 
     Returns:
         `RerunViewer` without spawning.
     """
+    save_dir = None if spawn_viewer else tmpdir_factory.mktemp("sample_recording")
+
     return RerunViewer(
         "test_viewer",
         cameras=["camera"],
-        spawn=spawn_viewer,  # set this to True for debugging
+        save_dir=save_dir,
     ).with_labels(label2id=label2id)


### PR DESCRIPTION
## What

This PR addresses the issue that no record will be saved even specified save directory.

With CLI, if user specified `-o --option` visualized recording will be saved in the specified directory.
Otherwise, the viewer will be spawned on the screen.