### PR TITLE
fix: append origin of trajectory

### DIFF
--- a/t4_devkit/viewer/record/box.py
+++ b/t4_devkit/viewer/record/box.py
@@ -174,7 +174,7 @@ class BatchBox3D:
         ]
 
         stripes = [
-            waypoints
+            np.vstack([record.center[None, :3], waypoints[:, :3]])  # (T, 3) -> (T+1, 3)
             for record in self.records
             if record.future is not None
             for _, waypoints in record.future


### PR DESCRIPTION
## What

This PR fixes the issue that future trajectories are visualized missing their origin.

Before

![Screenshot from 2025-05-13 17-21-04](https://github.com/user-attachments/assets/c98b1257-07d5-40b3-8939-267d1e5d4938)

After

![Screenshot from 2025-05-13 17-20-46](https://github.com/user-attachments/assets/33e94b2d-b0d2-4939-81f7-abe32291dbba)
