### PR TITLE
fix: Fix an error when converting null masks in object_ann and surface_ann

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "t4-devkit"
-version = "0.0.14"
+version = "0.0.13"
 description = "A toolkit to load and operate T4 dataset."
 authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "t4-devkit"
-version = "0.0.13"
+version = "0.0.14"
 description = "A toolkit to load and operate T4 dataset."
 authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"

--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field, validators
 from pycocotools import mask as cocomask
@@ -77,9 +77,10 @@ class ObjectAnn(SchemaBase):
         validator=validators.deep_iterable(validators.instance_of(str))
     )
     bbox: RoiLike = field(converter=tuple, validator=is_roi)
-    mask: RLEMask = field(
+    mask: Optional[RLEMask] = field(
+        default=None,
         converter=lambda x: RLEMask(**x) if isinstance(x, dict) else x,
-        validator=validators.instance_of(RLEMask),
+        validator=validators.optional(validators.instance_of(RLEMask)),
     )
     automatic_annotation: bool = field(default=False, validator=validators.instance_of(bool))
 

--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -12,7 +12,6 @@ from ..name import SchemaName
 from .base import SchemaBase
 from .registry import SCHEMAS
 
-
 if TYPE_CHECKING:
     from t4_devkit.typing import NDArrayU8, RoiLike
 

--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import base64
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attrs import define, field, validators
 from pycocotools import mask as cocomask
@@ -77,7 +77,7 @@ class ObjectAnn(SchemaBase):
         validator=validators.deep_iterable(validators.instance_of(str))
     )
     bbox: RoiLike = field(converter=tuple, validator=is_roi)
-    mask: Optional[RLEMask] = field(
+    mask: RLEMask | None = field(
         default=None,
         converter=lambda x: RLEMask(**x) if isinstance(x, dict) else x,
         validator=validators.optional(validators.instance_of(RLEMask)),

--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -12,6 +12,7 @@ from ..name import SchemaName
 from .base import SchemaBase
 from .registry import SCHEMAS
 
+
 if TYPE_CHECKING:
     from t4_devkit.typing import NDArrayU8, RoiLike
 

--- a/t4_devkit/schema/tables/surface_ann.py
+++ b/t4_devkit/schema/tables/surface_ann.py
@@ -10,6 +10,7 @@ from .base import SchemaBase
 from .object_ann import RLEMask
 from .registry import SCHEMAS
 
+
 if TYPE_CHECKING:
     from t4_devkit.typing import RoiLike
 
@@ -54,8 +55,8 @@ class SurfaceAnn(SchemaBase):
             Given as [xmin, ymin, xmax, ymax].
         """
         if self.mask is None:
-            return None	
-        
+            return None
+
         mask = self.mask.decode()
         indices = np.where(mask == 1)
         xmin, ymin = np.min(indices, axis=1)

--- a/t4_devkit/schema/tables/surface_ann.py
+++ b/t4_devkit/schema/tables/surface_ann.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from attrs import define, field, validators
@@ -36,9 +36,10 @@ class SurfaceAnn(SchemaBase):
 
     sample_data_token: str = field(validator=validators.instance_of(str))
     category_token: str = field(validator=validators.instance_of(str))
-    mask: RLEMask = field(
+    mask: Optional[RLEMask] = field(
+        default=None,
         converter=lambda x: RLEMask(**x) if isinstance(x, dict) else x,
-        validator=validators.instance_of(RLEMask),
+        validator=validators.optional(validators.instance_of(RLEMask)),
     )
     automatic_annotation: bool = field(default=False, validator=validators.instance_of(bool))
 

--- a/t4_devkit/schema/tables/surface_ann.py
+++ b/t4_devkit/schema/tables/surface_ann.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import numpy as np
 from attrs import define, field, validators
@@ -36,7 +36,7 @@ class SurfaceAnn(SchemaBase):
 
     sample_data_token: str = field(validator=validators.instance_of(str))
     category_token: str = field(validator=validators.instance_of(str))
-    mask: Optional[RLEMask] = field(
+    mask: RLEMask | None = field(
         default=None,
         converter=lambda x: RLEMask(**x) if isinstance(x, dict) else x,
         validator=validators.optional(validators.instance_of(RLEMask)),
@@ -47,12 +47,15 @@ class SurfaceAnn(SchemaBase):
     category_name: str = field(init=False, factory=str)
 
     @property
-    def bbox(self) -> RoiLike:
+    def bbox(self) -> RoiLike | None:
         """Return a bounding box corners calculated from polygon vertices.
 
         Returns:
             Given as [xmin, ymin, xmax, ymax].
         """
+        if self.mask is None:
+            return None	
+        
         mask = self.mask.decode()
         indices = np.where(mask == 1)
         xmin, ymin = np.min(indices, axis=1)

--- a/t4_devkit/schema/tables/surface_ann.py
+++ b/t4_devkit/schema/tables/surface_ann.py
@@ -10,7 +10,6 @@ from .base import SchemaBase
 from .object_ann import RLEMask
 from .registry import SCHEMAS
 
-
 if TYPE_CHECKING:
     from t4_devkit.typing import RoiLike
 


### PR DESCRIPTION
The validator will fail when our mask value is `null`, this PR fixes that by allowing passing `None` value` in `mask`.