### PR TITLE
fix: skip appending mask annotation if it is None

### DIFF
--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -682,6 +682,9 @@ def _append_mask(
     Returns:
         dict[str, dict[str, list]]: Updated `camera_masks`.
     """
+    if ann.mask is None:
+        return camera_masks
+
     if camera in camera_masks:
         camera_masks[camera]["masks"].append(ann.mask.decode())
         camera_masks[camera]["class_ids"].append(class_id)


### PR DESCRIPTION
## What

As of https://github.com/tier4/t4-devkit/pull/143, it is allowed that `mask` field in `ObjectAnn/SurfaceAnn` is None.
To avoid runtime exception, this PR updates to skip operations handing mask in these cases.