### PR TITLE
feat!: add support of loading dataset metadata

### DIFF
--- a/docs/tutorials/initialize.md
+++ b/docs/tutorials/initialize.md
@@ -25,7 +25,7 @@ You can initialize a `Tier4` instance as follows:
 
 >>> from t4_devkit import Tier4
 
->>> t4 = Tier4("annotation", "data/tier4/", verbose=True)
+>>> t4 = Tier4("data/tier4/", verbose=True)
 ======
 Loading T4 tables in `annotation`...
 Reverse indexing...

--- a/docs/tutorials/initialize.md
+++ b/docs/tutorials/initialize.md
@@ -2,22 +2,42 @@
 
 ---
 
-`Tier4` class expects the following dataset directly structure:
+`Tier4` class expects both following dataset directly structure with or without `<VERSION>` directory:
 
-```shell
-data/tier4/
-├── annotation ...contains `*.json` files.
-├── data
-│   ├── CAM_BACK
-│   ├── CAM_BACK_LEFT
-│   ├── CAM_BACK_RIGHT
-│   ├── CAM_FRONT
-│   ├── CAM_FRONT_LEFT
-│   ├── CAM_FRONT_RIGHT
-│   ├── LIDAR_CONCAT
-│   └── ...Other sensor channels
-...
-```
+- With `<VERSION>` directory:
+
+  ```shell
+  data/tier4/
+  └── <VERSION> ...version number
+      ├── annotation ...contains `*.json` files
+      ├── data
+      │   ├── CAM_BACK
+      │   ├── CAM_BACK_LEFT
+      │   ├── CAM_BACK_RIGHT
+      │   ├── CAM_FRONT
+      │   ├── CAM_FRONT_LEFT
+      │   ├── CAM_FRONT_RIGHT
+      │   ├── LIDAR_CONCAT
+      │   └── ...Other sensor channels
+      ...
+  ```
+
+- Without `<VERSION>` directory:
+
+  ```shell
+  data/tier4/
+  ├── annotation ...contains `*.json` files
+  ├── data
+  │   ├── CAM_BACK
+  │   ├── CAM_BACK_LEFT
+  │   ├── CAM_BACK_RIGHT
+  │   ├── CAM_FRONT
+  │   ├── CAM_FRONT_LEFT
+  │   ├── CAM_FRONT_RIGHT
+  │   ├── LIDAR_CONCAT
+  │   └── ...Other sensor channels
+  ...
+  ```
 
 You can initialize a `Tier4` instance as follows:
 

--- a/docs/tutorials/render.md
+++ b/docs/tutorials/render.md
@@ -5,8 +5,7 @@ If you want to visualize annotation results, `Tier4` supports some rendering met
 ### Scene
 
 ```python
->>> scene_token = t4.scene[0].token
->>> t4.render_scene(scene_token)
+>>> t4.render_scene()
 ```
 
 ![Render Scene GIF](../assets/render_scene.gif)
@@ -20,18 +19,21 @@ If you want to visualize annotation results, `Tier4` supports some rendering met
 
 ![Render Instance GIF](../assets/render_instance.gif)
 
-You can also render multiple instances at once:
+<!-- prettier-ignore-start -->
+!!! NOTE
+    You can also render multiple instances at once:
 
-```python
->>> instance_tokens = [inst.token for inst in t4.instance[:3]]
->>> t4.render_instance(instance_tokens)
-```
+    <!-- markdownlint-disable MD046 -->
+    ```python
+    >>> instance_tokens = [inst.token for inst in t4.instance[:3]]
+    >>> t4.render_instance(instance_tokens)
+    ```
+<!-- prettier-ignore-end -->
 
 ### PointCloud
 
 ```python
->>> scene_token = t4.scene[0].token
->>> t4.render_pointcloud(scene_token)
+>>> t4.render_pointcloud()
 ```
 
 ![Render PointCloud GIF](../assets/render_pointcloud.gif)
@@ -42,7 +44,7 @@ You can also render multiple instances at once:
 
     <!-- markdownlint-disable MD046 -->
     ```python
-    >>> t4.render_pointcloud(scene_token, ignore_distortion=True)
+    >>> t4.render_pointcloud(ignore_distortion=True)
     ```
 <!-- prettier-ignore-end -->
 

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -42,8 +42,7 @@ def scene(
     _create_dir(output)
 
     t4 = Tier4(data_root, verbose=False)
-    scene_token = t4.scene[0].token
-    t4.render_scene(scene_token, future_seconds=future, save_dir=output)
+    t4.render_scene(future_seconds=future, save_dir=output)
 
 
 @cli.command("instance", help="Visualize a particular instance in the corresponding scene.")
@@ -100,12 +99,7 @@ def pointcloud(
     _create_dir(output)
 
     t4 = Tier4(data_root, verbose=False)
-    scene_token = t4.scene[0].token
-    t4.render_pointcloud(
-        scene_token,
-        ignore_distortion=ignore_distortion,
-        save_dir=output,
-    )
+    t4.render_pointcloud(ignore_distortion=ignore_distortion, save_dir=output)
 
 
 def _create_dir(dir_path: str | None) -> None:

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -41,7 +41,7 @@ def scene(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4("annotation", data_root, verbose=False)
+    t4 = Tier4(data_root, verbose=False)
     scene_token = t4.scene[0].token
     t4.render_scene(scene_token, future_seconds=future, save_dir=output)
 
@@ -71,7 +71,7 @@ def instance(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4("annotation", data_root, verbose=False)
+    t4 = Tier4(data_root, verbose=False)
     t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output)
 
 
@@ -99,7 +99,7 @@ def pointcloud(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4("annotation", data_root, verbose=False)
+    t4 = Tier4(data_root, verbose=False)
     scene_token = t4.scene[0].token
     t4.render_pointcloud(
         scene_token,

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -97,7 +97,6 @@ class RenderingHelper:
 
     def render_scene(
         self,
-        scene_token: str,
         *,
         max_time_seconds: float = np.inf,
         future_seconds: float = 0.0,
@@ -106,7 +105,6 @@ class RenderingHelper:
         """Render specified scene.
 
         Args:
-            scene_token (str): Unique identifier of scene.
             max_time_seconds (float, optional): Max time length to be rendered [s].
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
@@ -132,7 +130,7 @@ class RenderingHelper:
         render3d = len(first_lidar_tokens) > 0 or len(first_radar_tokens) > 0
         render2d = len(first_camera_tokens) > 0
 
-        app_id = f"scene@{scene_token}"
+        app_id = f"scene@{self._t4.dataset_id}"
         viewer = self._init_viewer(
             app_id,
             render3d=render3d,
@@ -141,7 +139,7 @@ class RenderingHelper:
             save_dir=save_dir,
         )
 
-        scene: Scene = self._t4.get("scene", scene_token)
+        scene: Scene = self._t4.scene[0]
         first_sample: Sample = self._t4.get("sample", scene.first_sample_token)
         max_timestamp_us = first_sample.timestamp + sec2us(max_time_seconds)
 
@@ -212,7 +210,6 @@ class RenderingHelper:
             if last_sample is None or current_last_sample.timestamp > last_sample.timestamp:
                 last_sample = current_last_sample
 
-        scene_token = first_sample.scene_token
         max_timestamp_us = last_sample.timestamp
 
         # search first sample data tokens
@@ -235,7 +232,7 @@ class RenderingHelper:
         render3d = len(first_lidar_tokens) > 0 or len(first_radar_tokens) > 0
         render2d = len(first_camera_tokens) > 0
 
-        app_id = f"instance@{scene_token}"
+        app_id = f"instance@{self._t4.dataset_id}"
         viewer = self._init_viewer(
             app_id,
             render3d=render3d,
@@ -279,7 +276,6 @@ class RenderingHelper:
 
     def render_pointcloud(
         self,
-        scene_token: str,
         *,
         max_time_seconds: float = np.inf,
         ignore_distortion: bool = True,
@@ -288,7 +284,6 @@ class RenderingHelper:
         """Render pointcloud on 3D and 2D view.
 
         Args:
-            scene_token (str): Scene token.
             max_time_seconds (float, optional): Max time length to be rendered [s].
             ignore_distortion (bool, optional): Whether to ignore distortion parameters.
             save_dir (str | None, optional): Directory path to save the recording.
@@ -298,7 +293,7 @@ class RenderingHelper:
             Add an option of rendering radar channels.
         """
         # initialize viewer
-        app_id = f"pointcloud@{scene_token}"
+        app_id = f"pointcloud@{self._t4.dataset_id}"
         viewer = self._init_viewer(app_id, render_ann=False, save_dir=save_dir)
 
         # search first lidar sample data token

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -692,7 +692,6 @@ class Tier4:
 
     def render_scene(
         self,
-        scene_token: str,
         *,
         max_time_seconds: float = np.inf,
         future_seconds: float = 0.0,
@@ -701,13 +700,11 @@ class Tier4:
         """Render specified scene.
 
         Args:
-            scene_token (str): Unique identifier of scene.
             max_time_seconds (float, optional): Max time length to be rendered [s].
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
         """
         self._rendering_helper.render_scene(
-            scene_token=scene_token,
             max_time_seconds=max_time_seconds,
             future_seconds=future_seconds,
             save_dir=save_dir,
@@ -735,7 +732,6 @@ class Tier4:
 
     def render_pointcloud(
         self,
-        scene_token: str,
         *,
         max_time_seconds: float = np.inf,
         ignore_distortion: bool = True,
@@ -744,7 +740,6 @@ class Tier4:
         """Render pointcloud on 3D and 2D view.
 
         Args:
-            scene_token (str): Scene token.
             max_time_seconds (float, optional): Max time length to be rendered [s].
             save_dir (str | None, optional): Directory path to save the recording.
             ignore_distortion (bool, optional): Whether to ignore distortion parameters.
@@ -753,7 +748,6 @@ class Tier4:
             Add an option of rendering radar channels.
         """
         self._rendering_helper.render_pointcloud(
-            scene_token=scene_token,
             max_time_seconds=max_time_seconds,
             ignore_distortion=ignore_distortion,
             save_dir=save_dir,

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -84,7 +84,6 @@ class Tier4:
         """Load database and creates reverse indexes and shortcuts.
 
         Args:
-            version (str): Directory name of database json files.
             data_root (str): Path to the root directory of dataset.
             verbose (bool, optional): Whether to display status during load.
 


### PR DESCRIPTION
## What

This PR adds support of loading T4 dataset metadata including dataset ID and version.
Note that **the parameter of initializing `Tier4` class is changed from this PR as below.**

Now, we have the following dataset structure:

```shell
dataset1
└── 0
   ├── annotation
   ├── data
   ...
```

Then you can initialize 

```python
>>> from t4_devkit import Tier4

>>> t4 = Tier4("dataset1")
>>> t4.data_root
"dataset1/0"
>>> t4.dataset_id
"dataset1"
>>> t4.version
"0"
```

It is also allowed to load T4 dataset without version directory, then `version` returns `None`:

```shell
dataset2
├── annotation
├── data
 ...
```

```python
>>> from t4_devkit import Tier4

>>> t4 = Tier4("dataset1")
>>> t4.data_root
"dataset1"
>>> t4.dataset_id
"dataset1"
>>> t4.version
None
```