### PR TITLE
feat: enable to load a specific version of the dataset

### DIFF
--- a/docs/tutorials/cli/t4sanity.md
+++ b/docs/tutorials/cli/t4sanity.md
@@ -11,6 +11,7 @@ $ t4sanity -h
 ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ╭─ Options ────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
 │ --version             -v         Show the application version and exit.                                              │
+│ --revision            -rv   TEXT Specify if you want to load the specific version. [default: None]                   │
 │ --include-warning     -iw        Indicates whether to report any warnings.                                           │
 │ --install-completion             Install completion for the current shell.                                           │
 │ --show-completion                Show completion for the current shell, to copy it or customize the installation.    │

--- a/docs/tutorials/initialize.md
+++ b/docs/tutorials/initialize.md
@@ -71,6 +71,13 @@ Done loading in 0.061 seconds.
 ======
 ```
 
+Note that if you doesn't specify `revision` parameter in construction, it searches the latest version of the dataset.
+By specifying `revision=<VERSION>`, you can load the specific version of the dataset.
+
+```python
+>>> t4 = Tier4("data/tier4/", revision="2", verbose=True)
+```
+
 ## Access to Schema Fields
 
 ---

--- a/t4_devkit/cli/sanity.py
+++ b/t4_devkit/cli/sanity.py
@@ -18,13 +18,18 @@ cli = typer.Typer(
 )
 
 
-def _run_sanity_check(db_parent: str, *, include_warning: bool = False) -> list[DBException]:
+def _run_sanity_check(
+    db_parent: str,
+    *,
+    revision: str | None = None,
+    include_warning: bool = False,
+) -> list[DBException]:
     exceptions: list[DBException] = []
 
     db_dirs: list[Path] = Path(db_parent).glob("*")
 
     for db_root in tqdm(db_dirs, desc=">>>Sanity checking..."):
-        result = sanity_check(db_root, include_warning=include_warning)
+        result = sanity_check(db_root, revision=revision, include_warning=include_warning)
         if result:
             exceptions.append(result)
     return exceptions
@@ -41,11 +46,14 @@ def main(
         is_eager=True,
     ),
     db_parent: str = typer.Argument(..., help="Path to parent directory of the databases."),
+    revision: str | None = typer.Option(
+        None, "-rv", "--revision", help="Specify if you want to check the specific version."
+    ),
     include_warning: bool = typer.Option(
         False, "-iw", "--include-warning", help="Indicates whether to report any warnings."
     ),
 ) -> None:
-    exceptions = _run_sanity_check(db_parent, include_warning=include_warning)
+    exceptions = _run_sanity_check(db_parent, revision=revision, include_warning=include_warning)
 
     headers = ["DatasetID", "Version", "Message"]
     table = [[e.dataset_id, e.version, e.message] for e in exceptions]

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -20,6 +20,12 @@ cli = typer.Typer(
 @cli.command("scene", help="Visualize a specific scene.")
 def scene(
     data_root: Annotated[str, typer.Argument(help="Root directory path to the dataset.")],
+    revision: Annotated[
+        str | None,
+        typer.Option(
+            ..., "-rv", "--revision", help="Specify if you want to load the specific version."
+        ),
+    ] = None,
     future: Annotated[
         float,
         typer.Option(
@@ -41,7 +47,7 @@ def scene(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, verbose=False)
+    t4 = Tier4(data_root, revision=revision, verbose=False)
     t4.render_scene(future_seconds=future, save_dir=output)
 
 
@@ -49,6 +55,12 @@ def scene(
 def instance(
     data_root: Annotated[str, typer.Argument(help="Root directory path to the dataset.")],
     instance: Annotated[list[str], typer.Argument(help="Instance token(s).")],
+    revision: Annotated[
+        str | None,
+        typer.Option(
+            ..., "-rv", "--revision", help="Specify if you want to load the specific version."
+        ),
+    ] = None,
     future: Annotated[
         float,
         typer.Option(
@@ -70,13 +82,19 @@ def instance(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, verbose=False)
+    t4 = Tier4(data_root, revision=revision, verbose=False)
     t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output)
 
 
 @cli.command("pointcloud", help="Visualize pointcloud in the corresponding scene.")
 def pointcloud(
     data_root: Annotated[str, typer.Argument(help="Root directory path to the dataset.")],
+    revision: Annotated[
+        str | None,
+        typer.Option(
+            ..., "-rv", "--revision", help="Specify if you want to load the specific version."
+        ),
+    ] = None,
     ignore_distortion: Annotated[
         bool,
         typer.Option(
@@ -98,7 +116,7 @@ def pointcloud(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, verbose=False)
+    t4 = Tier4(data_root, revision=revision, verbose=False)
     t4.render_pointcloud(ignore_distortion=ignore_distortion, save_dir=output)
 
 

--- a/t4_devkit/common/sanity.py
+++ b/t4_devkit/common/sanity.py
@@ -19,11 +19,18 @@ class DBException:
     message: str
 
 
-def sanity_check(db_root: str | Path, *, include_warning: bool = False) -> DBException | None:
+def sanity_check(
+    db_root: str | Path,
+    *,
+    revision: str | None = None,
+    include_warning: bool = False,
+) -> DBException | None:
     """Perform sanity check and report exception or warning encountered while loading the dataset.
 
     Args:
         db_root (str | Path): Path to root directory of the dataset.
+        revision (str | None, optional): Specific version of the dataset.
+            If None, search the latest one.
         include_warning (bool, optional): Indicates whether to report warnings.
 
     Returns:
@@ -37,7 +44,7 @@ def sanity_check(db_root: str | Path, *, include_warning: bool = False) -> DBExc
             warnings.filterwarnings("ignore")
 
         try:
-            _ = Tier4(data_root=db_root, verbose=False)
+            _ = Tier4(data_root=db_root, revision=revision, verbose=False)
             exception = None
         except Exception as e:
             metadata = load_metadata(db_root)


### PR DESCRIPTION
## What

This PR allows users to load the specific version of the dataset by using `revision: str` parameter.
In the construction of `Tier4` class, you can specify `revision: str` as follows:

```python
from t4_devkit import Tier4

t4 = Tier4("data/t4", revision="2")
```

If you doesn't specify `revision`, it searches the latest one.