### PR TITLE
fix: resolve the case if the adjacent entity paths are duplicate

### DIFF
--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -30,11 +30,10 @@ if TYPE_CHECKING:
 __all__ = ["RerunViewer", "format_entity"]
 
 
-def format_entity(root: str, *entities: Sequence[str]) -> str:
+def format_entity(*entities: Sequence[str]) -> str:
     """Format entity path.
 
     Args:
-        root (str): Root entity path.
         *entities: Entity path(s).
 
     Returns:
@@ -48,15 +47,16 @@ def format_entity(root: str, *entities: Sequence[str]) -> str:
         >>> format_entity("map", "map/base_link", "camera")
         "map/base_link/camera"
     """
-    if len(entities) == 0:
-        return root
+    if not entities:
+        return ""
 
-    flattened = [s for t in entities for s in t.split("/")]
-
-    if osp.basename(root) == flattened[0]:
-        return osp.join(root, "/".join(flattened[1:])) if len(flattened) > 1 else root
-    else:
-        return osp.join(root, "/".join(entities))
+    flattened = []
+    for entity in entities:
+        for part in entity.split("/"):
+            if part and flattened and flattened[-1] == part:
+                continue
+            flattened.append(part)
+    return "/".join(flattened)
 
 
 class RerunViewer:

--- a/tests/viewer/test_viewer.py
+++ b/tests/viewer/test_viewer.py
@@ -14,6 +14,7 @@ def test_format_entity() -> None:
     assert "map/base_link" == format_entity("map", "base_link")
     assert "map/base_link" == format_entity("map", "map/base_link")
     assert "map/base_link/camera" == format_entity("map", "map/base_link", "camera")
+    assert "map/base_link/camera" == format_entity("map", "map/base_link", "base_link/camera")
 
 
 def test_render_box3ds(dummy_viewer, dummy_box3ds) -> None:


### PR DESCRIPTION
## What

This PR resolves the case if adjacent entity paths are duplicated `format_entity` function returns wrong path.

For example, previously, `format_entity("map", "map/base_link", "base_link/camera")` returns `"map/base_link/base_link/camera"`, but `"map/base_link/camera"` was expected path.

According to this PR, the above case will be passed.