### PR TITLE
feat: add DB status

### DIFF
--- a/docs/tutorials/cli/t4sanity.md
+++ b/docs/tutorials/cli/t4sanity.md
@@ -45,6 +45,13 @@ As an example, we have the following the dataset structure:
 ...
 ```
 
+Then, you can run sanity checks with `t4sanity <DATA_ROOT>`:
+
+```shell
+>>>Sanity checking...: 1it [00:00,  9.70it/s]
+✅ No exceptions occurred!!
+```
+
 ### Exclude Warnings
 
 To run sanity check ignoring warnings, providing the path to the parent directory of the datasets:
@@ -52,13 +59,14 @@ To run sanity check ignoring warnings, providing the path to the parent director
 ```shell
 $ t4sanity <DATA_ROOT>
 
->>> Sanity checking...: 97it [00:03, 26.60it/s]
-+--------------------------------------+---------+------------------------------------------------------------------------------------------------+
-|              DatasetID               | Version |                                            Message                                             |
-+--------------------------------------+---------+------------------------------------------------------------------------------------------------+
-| 96200480-ae59-44cb-9e4e-dd9021e250e8 |    2    | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1671, 198, 1440, 229) |
-| ca346afb-ea1a-4c5c-8117-544bd9ff6aca |    2    | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1793, 99, 1440, 222)  |
-...
+>>>Sanity checking...: 2it [00:00, 18.69it/s]
+⚠️  Encountered some exceptions!!
++-----------+---------+--------+------------------------------------------------------------------------------------------------+
+| DatasetID | Version | status |                                            Message                                             |
++-----------+---------+--------+------------------------------------------------------------------------------------------------+
+| dataset1  |    2    | ERROR  | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265) |
+| dataset2  |    1    |   OK   |                                                                                                |
++-----------+---------+--------+------------------------------------------------------------------------------------------------+
 ```
 
 ### Include Warnings
@@ -68,12 +76,12 @@ To run sanity check and report any warnings, use the `-iw; --include-warning` op
 ```shell
 $ t4sanity <DATA_ROOT> -iw
 
->>> Sanity checking...: 97it [00:03, 29.31it/s]
-+--------------------------------------+---------+------------------------------------------------------------------------------------------------+
-|              DatasetID               | Version |                                            Message                                             |
-+--------------------------------------+---------+------------------------------------------------------------------------------------------------+
-| 96200480-ae59-44cb-9e4e-dd9021e250e8 |    2    | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1671, 198, 1440, 229) |
-| ca346afb-ea1a-4c5c-8117-544bd9ff6aca |    2    | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1793, 99, 1440, 222)  |
-| ed96b707-e7f4-4a71-9e6b-571ffd56c4c4 |    2    |        level: Not available is not supported, Visibility.UNAVAILABLE will be assigned.         |
-...
+>>>Sanity checking...: 2it [00:00, 21.54it/s]
+⚠️  Encountered some exceptions!!
++-----------+---------+---------+------------------------------------------------------------------------------------------------+
+| DatasetID | Version | status  |                                            Message                                             |
++-----------+---------+---------+------------------------------------------------------------------------------------------------+
+| dataset1  |    2    |  ERROR  | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265) |
+| dataset2  |    1    | WARNING |           Category token is empty for surface ann: 0c15d9c143fb2723c16ac7e0c735b0a8            |
++-----------+---------+---------+------------------------------------------------------------------------------------------------+
 ```

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -86,13 +86,8 @@ def load_metadata(db_root: str, revision: str | None = None) -> DBMetadata:
             version = None
             data_root = db_root_path.as_posix()
     else:
-        if int(revision) not in version_candidates:
-            raise ValueError(f"The version: {revision} is not included in {dataset_id}")
         version = revision
         data_root = db_root_path.joinpath(version).as_posix()
-
-    if version is None:
-        warnings.warn(f"{dataset_id} does't contain any versions.", DeprecationWarning)
 
     return DBMetadata(data_root=data_root, dataset_id=dataset_id, version=version)
 
@@ -148,6 +143,11 @@ class Tier4:
 
         if not osp.exists(self.data_root):
             raise FileNotFoundError(f"Database directory is not found: {self.data_root}")
+
+        if self.version is None:
+            warnings.warn(
+                f"DatasetID: {self.dataset_id} does't contain any versions.", DeprecationWarning
+            )
 
         start_time = time.time()
         if verbose:


### PR DESCRIPTION
## What

This PR adds `DBStatus` enum to `DBException` for displaying status information.
This is used in `t4sanity` command.

In the case of any exceptions occurred:

```shell
>>>Sanity checking...: 2it [00:00, 18.61it/s]
⚠️  Encountered some exceptions!!
+--------------------------------------+---------+--------+------------------------------------------------------------------------------------------------+
|              DatasetID               | Version | status |                                            Message                                             |
+--------------------------------------+---------+--------+------------------------------------------------------------------------------------------------+
| 4ea652e7-76d5-4240-adb5-9d4ecac25eae |    2    | ERROR  | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265) |
| 70891309-ca8b-477b-905a-5156ffb3df65 |    1    |   OK   |                                                                                                |
+--------------------------------------+---------+--------+------------------------------------------------------------------------------------------------+
```

In the case of no exception occurred:

```shell
>>>Sanity checking...: 1it [00:00,  9.70it/s]
✅ No exceptions occurred!!
```