### PR TITLE
feat: add option to dump sanity check results into JSON

### DIFF
--- a/docs/tutorials/cli/t4sanity.md
+++ b/docs/tutorials/cli/t4sanity.md
@@ -63,7 +63,7 @@ $ t4sanity <DATA_ROOT>
 >>>Sanity checking...: 2it [00:00, 18.69it/s]
 ⚠️  Encountered some exceptions!!
 +-----------+---------+--------+------------------------------------------------------------------------------------------------+
-| DatasetID | Version | status |                                            Message                                             |
+| DatasetID | Version | Status |                                            Message                                             |
 +-----------+---------+--------+------------------------------------------------------------------------------------------------+
 | dataset1  |    2    | ERROR  | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265) |
 | dataset2  |    1    |   OK   |                                                                                                |
@@ -80,7 +80,7 @@ $ t4sanity <DATA_ROOT> -iw
 >>>Sanity checking...: 2it [00:00, 21.54it/s]
 ⚠️  Encountered some exceptions!!
 +-----------+---------+---------+------------------------------------------------------------------------------------------------+
-| DatasetID | Version | status  |                                            Message                                             |
+| DatasetID | Version | Status  |                                            Message                                             |
 +-----------+---------+---------+------------------------------------------------------------------------------------------------+
 | dataset1  |    2    |  ERROR  | bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265) |
 | dataset2  |    1    | WARNING |           Category token is empty for surface ann: 0c15d9c143fb2723c16ac7e0c735b0a8            |

--- a/t4_devkit/cli/sanity.py
+++ b/t4_devkit/cli/sanity.py
@@ -57,7 +57,7 @@ def main(
         print("✅ No exceptions occurred!!")
     else:
         print("⚠️  Encountered some exceptions!!")
-        headers = ["DatasetID", "Version", "status", "Message"]
+        headers = ["DatasetID", "Version", "Status", "Message"]
         table = [[e.dataset_id, e.version, e.status, e.message] for e in exceptions]
         print(tabulate(table, headers=headers, tablefmt="pretty"))
 


### PR DESCRIPTION
## What

This PR adds a feature to dump the results of t4sanity into JSON file with `-o; --output` option:

```shell
$ t4sanity <DATA_ROOT> -o results.json -iw

>>>Sanity checking...: 2it [00:00, 21.54it/s]
...
```

Then a JSON file named `results.json` will be generated:

```json
[
  {
    "dataset_id": "dataset1",
    "version": 2,
    "status": "ERROR",
    "message": "bbox must be (xmin, ymin, xmax, ymax) and xmin <= xmax && ymin <= ymax: (1532, 198, 1440, 265)"
  },
  {
    "dataset_id": "dataset2",
    "version": 1,
    "status": "WARNING",
    "message": "Category token is empty for surface ann: 0c15d9c143fb2723c16ac7e0c735b0a8"
  }
]
```
