### PR TITLE
refactor: display exact command name for -v option

### DIFF
--- a/t4_devkit/cli/version.py
+++ b/t4_devkit/cli/version.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 import importlib.metadata
 
+import click
 import typer
 from rich.console import Console
 
@@ -11,6 +12,7 @@ console = Console()
 
 def version_callback(value: bool) -> None:
     if value:
+        ctx = click.get_current_context()
         version = importlib.metadata.version("t4-devkit")
-        console.print(f"[bold green]t4viz[/bold green]: [cyan]{version}[/cyan]")
+        console.print(f"[bold green]{ctx.info_name}[/bold green]: [cyan]{version}[/cyan]")
         raise typer.Exit()


### PR DESCRIPTION
## What

This PR updates `version_callback` in order to display right command name.
