### PR TITLE
feat: add info_filename field to sample_data table

### DIFF
--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from attrs import define, field, validators
 

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -104,7 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
-    info_filename: str = field(default=None, validator=validators.instance_of(str))
+    info_filename: str | None = field(default=None, validator=validators.instance_of(str))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -104,7 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
-    info_filename: str = field(default="",validator=validators.instance_of(str))
+    info_filename: str = field(default="", validator=validators.instance_of(str))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -104,7 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
-    info_filename: str | None = field(default=None, validator=validators.instance_of(Optional[str]))
+    info_filename: str | None = field(default=None, validator=validators.optional(validators.instance_of(str)))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum, unique
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from attrs import define, field, validators
 
@@ -104,7 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
-    info_filename: str | None = field(default=None, validator=validators.instance_of(str))
+    info_filename: str | None = field(default=None, validator=validators.instance_of(Optional[str]))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -84,6 +84,7 @@ class SampleData(SchemaBase):
         prev (str): Foreign key pointing the sample_data that precedes this in time.
             Empty if start of scene.
         is_valid (bool): True if this data is valid, else False. Invalid data should be ignored.
+        info_filename (str): Relative path to metainfo data-blob on disk.
 
     Shortcuts:
     ---------
@@ -103,6 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
+    info_filename: str = field(default="",validator=validators.instance_of(str))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/t4_devkit/schema/tables/sample_data.py
+++ b/t4_devkit/schema/tables/sample_data.py
@@ -104,7 +104,7 @@ class SampleData(SchemaBase):
     next: str = field(validator=validators.instance_of(str))  # noqa: A003
     prev: str = field(validator=validators.instance_of(str))
     is_valid: bool = field(default=True, validator=validators.instance_of(bool))
-    info_filename: str = field(default="", validator=validators.instance_of(str))
+    info_filename: str = field(default=None, validator=validators.instance_of(str))
 
     # shortcuts
     modality: SensorModality | None = field(init=False, default=None)

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -221,6 +221,7 @@ def sample_data_dict() -> dict:
         "ego_pose_token": "d6779d73ac9c5a1f3f372aa182bc8158",
         "calibrated_sensor_token": "0c434d5a27ef0404331549435b9861e4",
         "filename": "data/camera/0.jpg",
+        "info_filename": "",
         "fileformat": "jpg",
         "width": 1440,
         "height": 1080,


### PR DESCRIPTION
This pull request introduces a minor schema update to the `SampleData` class in `t4_devkit/schema/tables/sample_data.py` to support tracking additional metadata for each sample. The most important change is the addition of a new field for storing the relative path to associated metainfo data.

Schema enhancements:

* Added a new string field `info_filename` to the `SampleData` class, which stores the relative path to metainfo data-blobs on disk. This field is now part of both the docstring and the class definition, with a default value of an empty string and appropriate type validation. [[1]](diffhunk://#diff-3e4c8c2231dc13b0f359ea2508d1040e71f524d3382d8e83225f5a3e43b6fecaR87) [[2]](diffhunk://#diff-3e4c8c2231dc13b0f359ea2508d1040e71f524d3382d8e83225f5a3e43b6fecaR107)

This field will point to the ConcatenatedPointCloudInfo file which contains information about the lidar indices, timestamps, and other meta info for the concatenated pointcloud.

References:

https://github.com/tier4/tier4_perception_dataset/pull/255