### PR TITLE
perf: execute annotation rendering in parallel

### DIFF
--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -265,7 +265,7 @@ class RenderingHelper:
                 viewer=viewer,
                 first_camera_tokens=first_camera_tokens,
                 max_timestamp_us=max_timestamp_us,
-            ),
+            )
             + [
                 self._executor.submit(
                     self._render_annotation3ds(

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -266,7 +266,7 @@ class RenderingHelper:
                 first_camera_tokens=first_camera_tokens,
                 max_timestamp_us=max_timestamp_us,
             ),
-            +[
+            + [
                 self._executor.submit(
                     self._render_annotation3ds(
                         viewer=viewer,

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -162,19 +162,23 @@ class RenderingHelper:
                 first_camera_tokens=first_camera_tokens,
                 max_timestamp_us=max_timestamp_us,
             )
-        )
-
-        # TODO(ktro2828): speed up annotation rendering
-        self._render_annotation3ds(
-            viewer=viewer,
-            first_sample_token=scene.first_sample_token,
-            max_timestamp_us=max_timestamp_us,
-            future_seconds=future_seconds,
-        )
-        self._render_annotation2ds(
-            viewer=viewer,
-            first_sample_token=scene.first_sample_token,
-            max_timestamp_us=max_time_seconds,
+            + [
+                self._executor.submit(
+                    self._render_annotation3ds(
+                        viewer=viewer,
+                        first_sample_token=scene.first_sample_token,
+                        max_timestamp_us=max_timestamp_us,
+                        future_seconds=future_seconds,
+                    )
+                ),
+                self._executor.submit(
+                    self._render_annotation2ds(
+                        viewer=viewer,
+                        first_sample_token=scene.first_sample_token,
+                        max_timestamp_us=max_time_seconds,
+                    )
+                ),
+            ]
         )
 
     def render_instance(
@@ -262,21 +266,25 @@ class RenderingHelper:
                 first_camera_tokens=first_camera_tokens,
                 max_timestamp_us=max_timestamp_us,
             ),
-        )
-
-        # TODO(ktro2828): speed up annotation rendering
-        self._render_annotation3ds(
-            viewer=viewer,
-            first_sample_token=first_sample.token,
-            max_timestamp_us=max_timestamp_us,
-            future_seconds=future_seconds,
-            instance_tokens=instance_tokens,
-        )
-        self._render_annotation2ds(
-            viewer=viewer,
-            first_sample_token=first_sample.token,
-            max_timestamp_us=max_timestamp_us,
-            instance_tokens=instance_tokens,
+            +[
+                self._executor.submit(
+                    self._render_annotation3ds(
+                        viewer=viewer,
+                        first_sample_token=first_sample.token,
+                        max_timestamp_us=max_timestamp_us,
+                        future_seconds=future_seconds,
+                        instance_tokens=instance_tokens,
+                    )
+                ),
+                self._executor.submit(
+                    self._render_annotation2ds(
+                        viewer=viewer,
+                        first_sample_token=first_sample.token,
+                        max_timestamp_us=max_timestamp_us,
+                        instance_tokens=instance_tokens,
+                    )
+                ),
+            ],
         )
 
     def render_pointcloud(

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -175,7 +175,7 @@ class RenderingHelper:
                     self._render_annotation2ds(
                         viewer=viewer,
                         first_sample_token=scene.first_sample_token,
-                        max_timestamp_us=max_time_seconds,
+                        max_timestamp_us=max_timestamp_us,
                     )
                 ),
             ]


### PR DESCRIPTION
## What

This pull request improves the performance of annotation rendering in the `t4_devkit/helper/rendering.py` module by parallelizing the rendering of 2D and 3D annotations. The main change is the use of the executor to submit annotation rendering tasks concurrently, which should result in faster rendering times for both scenes and instances.

Performance improvements in annotation rendering:

* In the `render_scene` method, the calls to `_render_annotation3ds` and `_render_annotation2ds` are now submitted to `self._executor` for parallel execution, allowing these tasks to run concurrently and speeding up the rendering process.
* In the `render_instance` method, the annotation rendering tasks (`_render_annotation3ds` and `_render_annotation2ds`) are also submitted in parallel using `self._executor`, improving efficiency for instance-level rendering.