### PR TITLE
feat: add support of rendering point cloud coloring with intensity

### DIFF
--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -494,7 +494,7 @@ class RenderingHelper:
             color_mode (PointCloudColorMode, optional): Color mode for pointcloud.
 
         Returns:
-            Projected points [2, n], their normalized features [n] and an image.
+            Projected points [2, n], their color values [n, 3], and an image.
         """
         point_sample_data: SampleData = self._t4.get("sample_data", point_sample_data_token)
         pc_filepath = osp.join(self._t4.data_root, point_sample_data.filename)

--- a/t4_devkit/viewer/color.py
+++ b/t4_devkit/viewer/color.py
@@ -1,31 +1,59 @@
 from __future__ import annotations
 
+from enum import Enum, unique
 from typing import TYPE_CHECKING
 
 import matplotlib
+import numpy as np
 
 if TYPE_CHECKING:
-    from t4_devkit.typing import ArrayLike, NDArrayF64, ScalarLike
+    from t4_devkit.dataclass import PointCloudLike
+    from t4_devkit.typing import ArrayLike, NDArrayF64
+
+
+@unique
+class PointCloudColorMode(str, Enum):
+    """Color mode of point cloud."""
+
+    DISTANCE = "distance"
+    INTENSITY = "intensity"
+
+
+def pointcloud_color(
+    pointcloud: PointCloudLike,
+    color_mode: PointCloudColorMode = PointCloudColorMode.INTENSITY,
+) -> NDArrayF64:
+    """Return color map depending on the specified color mode.
+
+    Args:
+        pointcloud (PointCloudLike): Any inheritance of `PointCloud` class.
+        color_mode (PointCloudColorMode): Color mode of point cloud.
+    """
+    match color_mode:
+        case PointCloudColorMode.DISTANCE:
+            values = np.linalg.norm(pointcloud.points[:3].T, axis=1)
+        case _:
+            values = pointcloud.points[3]
+
+    return distance_color(values)
 
 
 def distance_color(
-    distances: ScalarLike | ArrayLike,
+    distances: ArrayLike,
     cmap: str | None = None,
-    v_min: float = 3.0,
-    v_max: float = 75.0,
 ) -> tuple[float, float, float] | NDArrayF64:
     """Return color map depending on distance values.
 
     Args:
-        distances (ScalarLike | ArrayLike): Array of distances in the shape of (N,).
+        distances (ArrayLike): Array of distances in the shape of (N,).
         cmap (str | None, optional): Color map name in matplotlib. If None, `turbo_r` will be used.
-        v_min (float, optional): Min value to normalize.
-        v_max (float, optional): Max value to normalize.
 
     Returns:
         Color map in the shape of (N,). If input type is any number, returns a color as
             `tuple[float, float, float]`. Otherwise, returns colors as `NDArrayF64`.
     """
     color_map = matplotlib.colormaps["turbo_r"] if cmap is None else matplotlib.colormaps[cmap]
+    v_min = np.min(distances)
+    v_max = np.max(distances)
     norm = matplotlib.colors.Normalize(v_min, v_max)
     return color_map(norm(distances))

--- a/t4_devkit/viewer/color.py
+++ b/t4_devkit/viewer/color.py
@@ -24,13 +24,13 @@ class PointCloudColorMode(str, Enum):
 
 def pointcloud_color(
     pointcloud: PointCloudLike,
-    color_mode: PointCloudColorMode = PointCloudColorMode.INTENSITY,
+    color_mode: PointCloudColorMode = PointCloudColorMode.DISTANCE,
 ) -> NDArrayF64:
     """Return color map depending on the specified color mode.
 
     Args:
         pointcloud (PointCloudLike): Any inheritance of `PointCloud` class.
-        color_mode (PointCloudColorMode): Color mode of point cloud.
+        color_mode (PointCloudColorMode, optional): Color mode for pointcloud.
     """
     match color_mode:
         case PointCloudColorMode.DISTANCE:

--- a/t4_devkit/viewer/color.py
+++ b/t4_devkit/viewer/color.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from t4_devkit.typing import ArrayLike, NDArrayF64
 
 
+__all__ = ["PointCloudColorMode", "pointcloud_color", "normalize_color"]
+
+
 @unique
 class PointCloudColorMode(str, Enum):
     """Color mode of point cloud."""
@@ -35,25 +38,22 @@ def pointcloud_color(
         case _:
             values = pointcloud.points[3]
 
-    return distance_color(values)
+    return normalize_color(values)
 
 
-def distance_color(
-    distances: ArrayLike,
-    cmap: str | None = None,
-) -> tuple[float, float, float] | NDArrayF64:
-    """Return color map depending on distance values.
+def normalize_color(values: ArrayLike, cmap: str | None = None, alpha: float = 1.0) -> NDArrayF64:
+    """Return color map normalizing values.
 
     Args:
-        distances (ArrayLike): Array of distances in the shape of (N,).
+        values (ArrayLike): Array of values in the shape of (N,).
         cmap (str | None, optional): Color map name in matplotlib. If None, `turbo_r` will be used.
+        alpha (float, optional): Alpha value of color map.
 
     Returns:
-        Color map in the shape of (N,). If input type is any number, returns a color as
-            `tuple[float, float, float]`. Otherwise, returns colors as `NDArrayF64`.
+        Color map in the shape of (N,).
     """
     color_map = matplotlib.colormaps["turbo_r"] if cmap is None else matplotlib.colormaps[cmap]
-    v_min = np.min(distances)
-    v_max = np.max(distances)
+    v_min = np.min(values)
+    v_max = np.max(values)
     norm = matplotlib.colors.Normalize(v_min, v_max)
-    return color_map(norm(distances))
+    return color_map(norm(values), alpha=alpha)

--- a/t4_devkit/viewer/color.py
+++ b/t4_devkit/viewer/color.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from t4_devkit.typing import ArrayLike, NDArrayF64
 
 
-__all__ = ["PointCloudColorMode", "pointcloud_color", "normalize_color"]
+__all__ = ["PointCloudColorMode", "pointcloud_color"]
 
 
 @unique
@@ -38,10 +38,10 @@ def pointcloud_color(
         case _:
             values = pointcloud.points[3]
 
-    return normalize_color(values)
+    return _normalize_color(values)
 
 
-def normalize_color(values: ArrayLike, cmap: str | None = None, alpha: float = 1.0) -> NDArrayF64:
+def _normalize_color(values: ArrayLike, cmap: str | None = None, alpha: float = 1.0) -> NDArrayF64:
     """Return color map normalizing values.
 
     Args:

--- a/t4_devkit/viewer/color.py
+++ b/t4_devkit/viewer/color.py
@@ -35,8 +35,10 @@ def pointcloud_color(
     match color_mode:
         case PointCloudColorMode.DISTANCE:
             values = np.linalg.norm(pointcloud.points[:3].T, axis=1)
-        case _:
+        case PointCloudColorMode.INTENSITY:
             values = pointcloud.points[3]
+        case _:
+            raise ValueError(f"Unsupported color mode: {color_mode}")
 
     return _normalize_color(values)
 

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -12,7 +12,7 @@ from t4_devkit.common.timestamp import us2sec
 from t4_devkit.lanelet import LaneletParser
 from t4_devkit.schema import SensorModality
 
-from .color import pointcloud_color
+from .color import PointCloudColorMode, pointcloud_color
 from .config import ViewerConfig, format_entity
 from .geography import calculate_geodetic_point
 from .lanelet import (
@@ -408,18 +408,25 @@ class RerunViewer:
         )
 
     @_check_spatial3d
-    def render_pointcloud(self, seconds: float, channel: str, pointcloud: PointCloudLike) -> None:
+    def render_pointcloud(
+        self,
+        seconds: float,
+        channel: str,
+        pointcloud: PointCloudLike,
+        color_mode: PointCloudColorMode = PointCloudColorMode.DISTANCE,
+    ) -> None:
         """Render pointcloud.
 
         Args:
             seconds (float): Timestamp in [sec].
             channel (str): Name of the pointcloud sensor channel.
             pointcloud (PointCloudLike): Inherence object of `PointCloud`.
+            color_mode (PointCloudColorMode, optional): Color mode for pointcloud.
         """
         # TODO(ktro2828): add support of rendering pointcloud on images
         rr.set_time_seconds(self.config.timeline, seconds)
 
-        colors = pointcloud_color(pointcloud)
+        colors = pointcloud_color(pointcloud, color_mode=color_mode)
         rr.log(
             format_entity(self.config.ego_entity, channel),
             rr.Points3D(pointcloud.points[:3].T, colors=colors),

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -12,7 +12,7 @@ from t4_devkit.common.timestamp import us2sec
 from t4_devkit.lanelet import LaneletParser
 from t4_devkit.schema import SensorModality
 
-from .color import distance_color
+from .color import pointcloud_color
 from .config import ViewerConfig, format_entity
 from .geography import calculate_geodetic_point
 from .lanelet import (
@@ -419,7 +419,7 @@ class RerunViewer:
         # TODO(ktro2828): add support of rendering pointcloud on images
         rr.set_time_seconds(self.config.timeline, seconds)
 
-        colors = distance_color(np.linalg.norm(pointcloud.points[:3].T, axis=1))
+        colors = pointcloud_color(pointcloud)
         rr.log(
             format_entity(self.config.ego_entity, channel),
             rr.Points3D(pointcloud.points[:3].T, colors=colors),


### PR DESCRIPTION
## What

This pull request introduces a new color mapping system for point cloud visualization, improving flexibility and maintainability. The main change is the addition of a `PointCloudColorMode` enum and a `pointcloud_color` function, allowing selection of color modes (distance or intensity) when rendering point clouds. The viewer now uses this new system instead of directly calculating distance-based colors.

**Point cloud color mapping improvements:**

* Added a `PointCloudColorMode` enum to define selectable color modes for point cloud visualization, supporting both distance and intensity modes. (`t4_devkit/viewer/color.py`)
* Implemented a new `pointcloud_color` function that returns color maps based on the selected color mode, improving extensibility and code clarity. (`t4_devkit/viewer/color.py`)
* Updated the viewer to use `pointcloud_color` instead of `distance_color`, enabling the new color mode selection for point cloud rendering. (`t4_devkit/viewer/viewer.py`) [[1]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L17-R17) [[2]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L458-R458)

**Refactoring and API consistency:**

* Refactored the `distance_color` function to remove unused arguments and improve normalization by automatically setting `v_min` and `v_max` based on input values. (`t4_devkit/viewer/color.py`)

### Color by distance (current) vs intensity

- Distance

<img width="1920" height="1080" alt="Screenshot from 2025-09-11 00-59-15" src="https://github.com/user-attachments/assets/4202d5a1-c7af-497f-80b6-41001e0fdf92" />

- Intensity

<img width="1920" height="1080" alt="Screenshot from 2025-09-11 00-59-23" src="https://github.com/user-attachments/assets/1fa5cc97-27c1-4b30-9ec0-e9edcfda7966" />


### How to Test

```shell
t4viz pointcloud <DATASET_PATH>
```
