### PR TITLE
fix: resolve camera resolution warning

### DIFF
--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -352,7 +352,14 @@ class RenderingHelper:
             "calibrated_sensor", sample_data.calibrated_sensor_token
         )
         sensor: Sensor = self._t4.get("sensor", calibration.sensor_token)
-        viewer.render_calibration(sensor=sensor, calibration=calibration)
+        if sensor.modality == SensorModality.CAMERA:
+            viewer.render_calibration(
+                sensor=sensor,
+                calibration=calibration,
+                resolution=(sample_data.width, sample_data.height),
+            )
+        else:
+            viewer.render_calibration(sensor=sensor, calibration=calibration)
 
     def _render_lidar_and_ego(
         self,

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -27,7 +27,14 @@ from .record import BatchBox2D, BatchBox3D, BatchSegmentation2D
 if TYPE_CHECKING:
     from t4_devkit.dataclass import Box2D, Box3D, Future, PointCloudLike
     from t4_devkit.schema import CalibratedSensor, EgoPose, Sensor
-    from t4_devkit.typing import CamIntrinsicLike, NDArrayU8, RoiLike, RotationLike, Vector3Like
+    from t4_devkit.typing import (
+        CamIntrinsicLike,
+        NDArrayU8,
+        RoiLike,
+        RotationLike,
+        Vector2Like,
+        Vector3Like,
+    )
 
 __all__ = ["RerunViewer", "format_entity"]
 
@@ -563,12 +570,14 @@ class RerunViewer:
         self,
         sensor: Sensor,
         calibration: CalibratedSensor,
+        resolution: Vector2Like | None = None,
     ) -> None:
         """Render a sensor calibration.
 
         Args:
             sensor (Sensor): `Sensor` object.
             calibration (CalibratedSensor): `CalibratedSensor` object.
+            resolution (Vector2Like | None, optional): Camera resolution (width, height).
         """
         pass
 
@@ -580,6 +589,7 @@ class RerunViewer:
         translation: Vector3Like,
         rotation: RotationLike,
         camera_intrinsic: CamIntrinsicLike | None = None,
+        resolution: Vector2Like | None = None,
     ) -> None:
         """Render a sensor calibration.
 
@@ -589,13 +599,13 @@ class RerunViewer:
             translation (Vector3Like): Sensor translation in ego centric coords.
             rotation (RotationLike): Sensor rotation in ego centric coords.
             camera_intrinsic (CamIntrinsicLike | None, optional): Camera intrinsic matrix.
-                Defaults to None.
+            resolution (Vector2Like | None, optional): Camera resolution (width, height).
         """
         pass
 
     def render_calibration(self, *args, **kwargs) -> None:
         """Render a sensor calibration."""
-        if len(args) + len(kwargs) == 2:
+        if len(args) + len(kwargs) <= 3:
             self._render_calibration_with_schema(*args, **kwargs)
         else:
             self._render_calibration_without_schema(*args, **kwargs)
@@ -604,6 +614,7 @@ class RerunViewer:
         self,
         sensor: Sensor,
         calibration: CalibratedSensor,
+        resolution: Vector2Like | None = None,
     ) -> None:
         self._render_calibration_without_schema(
             channel=sensor.channel,
@@ -611,6 +622,7 @@ class RerunViewer:
             translation=calibration.translation,
             rotation=calibration.rotation,
             camera_intrinsic=calibration.camera_intrinsic,
+            resolution=resolution,
         )
 
     def _render_calibration_without_schema(
@@ -620,6 +632,7 @@ class RerunViewer:
         translation: Vector3Like,
         rotation: RotationLike,
         camera_intrinsic: CamIntrinsicLike | None = None,
+        resolution: Vector2Like | None = None,
     ) -> None:
         """Render a sensor calibration.
 
@@ -629,7 +642,7 @@ class RerunViewer:
             translation (Vector3Like): Sensor translation in ego centric coords.
             rotation (RotationLike): Sensor rotation in ego centric coords.
             camera_intrinsic (CamIntrinsicLike | None, optional): Camera intrinsic matrix.
-                Defaults to None.
+            resolution (Vector2Like | None, optional): Camera resolution (width, height).
         """
         rr.log(
             format_entity(self.ego_entity, channel),
@@ -640,7 +653,7 @@ class RerunViewer:
         if modality == SensorModality.CAMERA:
             rr.log(
                 format_entity(self.ego_entity, channel),
-                rr.Pinhole(image_from_camera=camera_intrinsic),
+                rr.Pinhole(image_from_camera=camera_intrinsic, resolution=resolution),
                 static=True,
             )
 


### PR DESCRIPTION
## What

This pull request enhances the rendering of sensor calibration, specifically improving support for camera sensors by allowing camera resolution to be passed through the rendering pipeline. The main changes involve updating the `render_calibration` methods in the `RerunViewer` to accept an optional `resolution` parameter and ensuring this information is properly handled and logged for camera modalities.

**Camera calibration improvements:**

* Updated the `render_calibration` and related methods (`_render_calibration_with_schema`, `_render_calibration_without_schema`) in `t4_devkit/viewer/viewer.py` to accept an optional `resolution` parameter, allowing camera resolution (width, height) to be specified and passed through the rendering pipeline. [[1]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R573-R580) [[2]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R592) [[3]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L592-R608) [[4]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R617-R625) [[5]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R635) [[6]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L632-R645)
* Modified the logging for camera sensors to include the resolution in the `rr.Pinhole` call, ensuring that the camera's image size is accurately represented in the visualization.
* Updated the `_render_sensor_calibration` method in `t4_devkit/helper/rendering.py` to pass the sample data's width and height as resolution when rendering camera calibrations.

**Type and import updates:**

* Added `Vector2Like` to the imports from `t4_devkit.typing` in `t4_devkit/viewer/viewer.py` to support the new resolution parameter type.