### PR TITLE
style: add typing

### DIFF
--- a/t4_devkit/schema/tables/autolabel_metadata.py
+++ b/t4_devkit/schema/tables/autolabel_metadata.py
@@ -31,11 +31,11 @@ class AutolabelModel:
     )
 
     @staticmethod
-    def to_autolabel_model(x) -> list[AutolabelModel] | None:
+    def to_autolabel_model(x: list[dict | AutolabelModel] | None) -> list[AutolabelModel] | None:
         """Convert input to a list of AutolabelModel instances.
 
         Args:
-            x: Input to convert. Can be None, a list of dicts, or a list of AutolabelModel instances.
+            x (list[dict | AutolabelModel] | None): Input to convert. Can be None, a list of dicts, or a list of AutolabelModel instances.
 
         Returns:
             list[AutolabelModel] | None: Converted list of AutolabelModel instances or None.


### PR DESCRIPTION
## What

This pull request makes a minor update to the type annotation and docstring for the `to_autolabel_model` static method in the `AutolabelModel` class. The change improves code clarity and documentation.

* Updated the type annotation for the `x` parameter in the `to_autolabel_model` method to explicitly specify `list | None`, and revised the docstring to match the new annotation. (`t4_devkit/schema/tables/autolabel_metadata.py`)