### PR TITLE
chore(deps): bump rerun to v0.25.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "rerun-sdk==0.20.0",
+    "rerun-sdk==0.25.0",
     "pyquaternion>=0.9.9",
     "matplotlib>=3.9.2",
     "shapely<2.0.0; python_version=='3.10'",

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -197,7 +197,7 @@ class RerunViewer:
             self._render_box3ds_with_elements(*args, **kwargs)
 
     def _render_box3ds_with_boxes(self, seconds: float, boxes: Sequence[Box3D]) -> None:
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         batches: dict[str, BatchBox3D] = {}
         for box in boxes:
@@ -270,7 +270,7 @@ class RerunViewer:
                 future=future,
             )
 
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         rr.log(format_entity(self.config.map_entity, frame_id, "box"), batch.as_boxes3d())
 
@@ -326,7 +326,7 @@ class RerunViewer:
             self._render_box2ds_with_elements(*args, **kwargs)
 
     def _render_box2ds_with_boxes(self, seconds: float, boxes: Sequence[Box2D]) -> None:
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         batches: dict[str, BatchBox2D] = {}
         for box in boxes:
@@ -355,7 +355,7 @@ class RerunViewer:
         for roi, class_id, uuid in zip(rois, class_ids, uuids, strict=True):
             batch.append(roi=roi, class_id=class_id, uuid=uuid)
 
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
         rr.log(format_entity(self.config.ego_entity, camera, "box"), batch.as_boxes2d())
 
     @_check_spatial2d
@@ -377,7 +377,7 @@ class RerunViewer:
             class_ids (Sequence[int]): Sequence of label ids.
             uuids (Sequence[str | None] | None, optional): Sequence of each instance ID.
         """
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         batch = BatchSegmentation2D()
         if uuids is None:
@@ -400,7 +400,7 @@ class RerunViewer:
             pointcloud (PointCloudLike): Inherence object of `PointCloud`.
         """
         # TODO(ktro2828): add support of rendering pointcloud on images
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         colors = distance_color(np.linalg.norm(pointcloud.points[:3].T, axis=1))
         rr.log(
@@ -417,7 +417,7 @@ class RerunViewer:
             camera (str): Name of the camera channel.
             image (str | NDArrayU8): Image tensor or path of the image file.
         """
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         if isinstance(image, str):
             rr.log(format_entity(self.config.ego_entity, camera), rr.ImageEncoded(path=image))
@@ -476,7 +476,7 @@ class RerunViewer:
         rotation: RotationLike,
         geocoordinate: Vector3Like | None = None,
     ) -> None:
-        rr.set_time_seconds(self.config.timeline, seconds)
+        rr.set_time(self.config.timeline, duration=seconds)
 
         rr.log(
             self.config.ego_entity,


### PR DESCRIPTION
## What

This pull request updates the `rerun-sdk` dependency and refactors several rendering methods in `t4_devkit/viewer/viewer.py` to use a new time-setting API. The main change is replacing `rr.set_time_seconds` with `rr.set_time`, which likely aligns with updates in the `rerun-sdk` API for improved time management consistency.

Dependency update:

* Upgraded `rerun-sdk` from version `0.20.0` to `0.25.0` in `pyproject.toml`, ensuring compatibility with the latest features and fixes.

Rendering API refactor (all in `t4_devkit/viewer/viewer.py`):

* Replaced all instances of `rr.set_time_seconds(self.config.timeline, seconds)` with `rr.set_time(self.config.timeline, duration=seconds)` across rendering functions for 3D/2D boxes, segmentation, point clouds, images, and ego rendering, reflecting the new API usage. [[1]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L200-R200) [[2]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L273-R273) [[3]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L329-R329) [[4]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L358-R358) [[5]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L380-R380) [[6]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L403-R403) [[7]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L420-R420) [[8]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L479-R479)