### PR TITLE
feat: display street map if lanelet file exists

### DIFF
--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import concurrent
 import concurrent.futures
 import os.path as osp
-import warnings
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Sequence
 
@@ -80,6 +79,8 @@ class RenderingHelper:
             map_origin: dict = map_metadata["/**"]["ros__parameters"]["map_origin"]
             latitude, longitude = map_origin["latitude"], map_origin["longitude"]
             builder = builder.with_streetmap((latitude, longitude))
+        elif osp.exists(osp.join(self._t4.map_dir, "lanelet2_map.osm")):
+            builder = builder.with_streetmap()
 
         return builder.build(app_id, save_dir=save_dir)
 
@@ -309,10 +310,6 @@ class RenderingHelper:
 
     def _render_map(self, viewer: RerunViewer) -> None:
         lanelet_path = osp.join(self._t4.map_dir, "lanelet2_map.osm")
-        if not osp.exists(lanelet_path):
-            warnings.warn(f"Lanelet map not found at {lanelet_path}")
-            return
-
         viewer.render_map(lanelet_path)
 
     def _render_sensor_calibration(self, viewer: RerunViewer, sample_data_token: str) -> None:

--- a/t4_devkit/viewer/builder.py
+++ b/t4_devkit/viewer/builder.py
@@ -54,11 +54,12 @@ class ViewerBuilder:
         self._config.label2id = label2id
         return self
 
-    def with_streetmap(self, latlon: Vector2Like) -> Self:
+    def with_streetmap(self, latlon: Vector2Like | None = None) -> Self:
         self._config.spatial3ds.append(
             rrb.MapView(name="Map", origin=self._config.geocoordinate_entity)
         )
-        self._config.latlon = latlon
+        if latlon is not None:
+            self._config.latlon = latlon
         return self
 
     def build(self, app_id: str, save_dir: str | None = None) -> RerunViewer:

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -72,6 +72,23 @@ def _check_spatial2d(function: Callable) -> Callable:
     return checker
 
 
+def _check_filepath(function: Callable) -> Callable:
+    """Check if the input filepath exists.
+
+    Note:
+        This function is supposed to be used as a decorator for methods of RerunViewer.
+    """
+
+    def checker(viewer: RerunViewer, filepath: str):
+        if not osp.exists(filepath):
+            warnings.warn(f"File not found: {filepath}")
+            return
+        else:
+            return function(viewer, filepath)
+
+    return checker
+
+
 class RerunViewer:
     """A viewer class that renders some components powered by rerun."""
 
@@ -593,6 +610,7 @@ class RerunViewer:
                 static=True,
             )
 
+    @_check_filepath
     @_check_spatial3d
     def render_map(self, filepath: str) -> None:
         """Render vector map.


### PR DESCRIPTION
## What

This pull request refactors how map files are handled and rendered in the viewer, improving error handling and simplifying the code. The most important changes include moving file existence checks to a new decorator, updating method signatures for flexibility, and cleaning up unnecessary warnings.

**Rendering and error handling improvements:**

* Added a `_check_filepath` decorator in `t4_devkit/viewer/viewer.py` to centralize file existence checks and warning messages for missing files, and applied it to the `render_map` method. This removes the need for manual file checks and warnings elsewhere. [[1]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R75-R91) [[2]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88R613)

**Code simplification and flexibility:**

* Removed manual lanelet map existence checks and warnings from `_render_map` in `t4_devkit/helper/rendering.py`, relying on the new decorator for error handling.
* Updated `with_streetmap` in `t4_devkit/viewer/builder.py` to accept an optional `latlon` parameter, enabling map rendering even when coordinates are not provided.
* Modified `_init_viewer` in `t4_devkit/helper/rendering.py` to call `with_streetmap()` without coordinates if only the map file exists, improving robustness when metadata is missing.

**Minor cleanup:**

* Removed unused `warnings` import from `t4_devkit/helper/rendering.py`.