### PR TITLE
docs: add version selector for mike

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -48,6 +48,8 @@ theme:
 
 plugins:
   - search
+  - mike:
+      version_selector: true
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
## What

This pull request makes a small configuration update to the `mkdocs.yaml` file. The change adds the `mike` plugin with the `version_selector` option enabled, which allows users to select documentation versions in the site.