### PR TITLE
ci: update deployment process for the documentation

### DIFF
--- a/.github/workflows/deploy-document.yaml
+++ b/.github/workflows/deploy-document.yaml
@@ -8,13 +8,16 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Version to deploy (e.g., v1.0.0, latest, dev)"
+        description: "Version to deploy (e.g., v1.0.0, latest, develop)"
         required: true
-        default: "latest"
+        default: "develop"
       alias:
         description: "Version alias (e.g., latest, stable)"
         required: false
         default: ""
+
+permissions:
+  contents: write # Required for mike to push to gh-pages branch
 
 jobs:
   deploy-document:
@@ -45,27 +48,38 @@ jobs:
             VERSION="${{ github.event.inputs.version }}"
             ALIAS="${{ github.event.inputs.alias }}"
           elif [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            # For version tags (e.g., v1.0.0), use the tag name and set latest alias
             VERSION="${{ github.ref_name }}"
             ALIAS="latest"
           else
+            # For main branch pushes (non-tag), deploy as develop
             VERSION="develop"
             ALIAS=""
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "alias=$ALIAS" >> $GITHUB_OUTPUT
-          echo "Deploying version: $VERSION"
+          echo "Deploying version: $VERSION with alias: $ALIAS"
 
       - name: Deploy documentation
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           ALIAS="${{ steps.version.outputs.alias }}"
 
+          echo "Deploying documentation for version: $VERSION"
           if [[ -n "$ALIAS" ]]; then
+            echo "Setting alias: $ALIAS"
             uv run mike deploy --push --update-aliases $VERSION $ALIAS
             uv run mike set-default --push $ALIAS
           else
+            echo "No alias set"
             uv run mike deploy --push $VERSION
           fi
+        env:
+          # Ensure GitHub Pages deployment works correctly
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: List versions
-        run: uv run mike list
+      - name: List deployed versions
+        run: |
+          echo "Currently deployed versions:"
+          uv run mike list
+          echo "Documentation deployment completed successfully!"

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -50,6 +50,7 @@ plugins:
   - search
   - mike:
       version_selector: true
+      canonical_version: latest
   - mkdocstrings:
       handlers:
         python:


### PR DESCRIPTION
## What

This pull request updates the documentation deployment workflow and configuration to improve version handling and deployment clarity. The changes ensure that documentation is deployed with the correct version and alias, and that permissions and environment variables are properly set for GitHub Pages. Additionally, the documentation site configuration is updated to specify a canonical version.

**Workflow improvements and clarity:**

* Updated the deploy workflow to use "develop" as the default version instead of "latest", and clarified the input description for version selection in `.github/workflows/deploy-document.yaml`.
* Enhanced deployment logic to explicitly set version and alias based on branch or tag, added more informative logging, and ensured the required permissions and environment variables are set for GitHub Pages deployment in `.github/workflows/deploy-document.yaml`.

**Documentation configuration:**

* Added `canonical_version: latest` to the `mike` plugin configuration in `mkdocs.yaml` to specify the canonical documentation version.