### PR TITLE
refactor: remove unused projection parameter

### DIFF
--- a/docs/tutorials/render.md
+++ b/docs/tutorials/render.md
@@ -71,7 +71,7 @@ To initialize `RerunViewer`, you can use the `ViewerBuilder` class:
 >>> viewer = (
         ViewerBuilder()
         .with_spatial3d()
-        .with_spatial2d(cameras=["CAM_FRONT", "CAM_BACK"], projection=True)
+        .with_spatial2d(cameras=["CAM_FRONT", "CAM_BACK"])
         .with_labels({"car": 1, "pedestrian": 2})
         .build("foo")
     )

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -70,11 +70,7 @@ class RenderingHelper:
             sensor.channel for sensor in self._t4.sensor if sensor.modality == SensorModality.CAMERA
         ]
 
-        # project 3D boxes if there is no 2D annotation
-        projection = len(self._t4.object_ann) == 0 and len(self._t4.surface_ann) == 0
-        builder = (
-            ViewerBuilder().with_spatial3d().with_spatial2d(cameras=cameras, projection=projection)
-        )
+        builder = ViewerBuilder().with_spatial3d().with_spatial2d(cameras=cameras)
 
         if render_ann:
             builder = builder.with_labels(self._label2id)

--- a/t4_devkit/viewer/builder.py
+++ b/t4_devkit/viewer/builder.py
@@ -36,15 +36,10 @@ class ViewerBuilder:
         self._config.spatial3ds.append(rrb.Spatial3DView(name="3D", origin=ViewerConfig.map_entity))
         return self
 
-    def with_spatial2d(self, cameras: Sequence[str], *, projection: bool = False) -> Self:
-        overrides = {}  # TODO(ktro2828): add support of projecting 3D elements on image
+    def with_spatial2d(self, cameras: Sequence[str]) -> Self:
         self._config.spatial2ds.extend(
             [
-                rrb.Spatial2DView(
-                    name=name,
-                    origin=format_entity(ViewerConfig.ego_entity, name),
-                    overrides=overrides,
-                )
+                rrb.Spatial2DView(name=name, origin=format_entity(ViewerConfig.ego_entity, name))
                 for name in cameras
             ]
         )


### PR DESCRIPTION
## What

This pull request simplifies the initialization of spatial 2D views in the viewer by removing the `projection` parameter from both the `ViewerBuilder.with_spatial2d` method and its usage throughout the codebase. This change streamlines the API and eliminates logic that conditionally set projection based on annotation presence.

Viewer API simplification:

* Removed the `projection` parameter from the `ViewerBuilder.with_spatial2d` method signature and its internal usage in `t4_devkit/viewer/builder.py`.
* Updated all usages of `with_spatial2d` in the codebase and documentation to no longer pass the `projection` argument, including in `t4_devkit/helper/rendering.py` and `docs/tutorials/render.md`. [[1]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2L73-R73) [[2]](diffhunk://#diff-9aaaa8fc77277b09c6faa509af00b429754db7407a1f2d5b7594550951fdd7eaL74-R74)