### PR TITLE
refactor: rename status

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,4 +1,4 @@
-## CLI Support
+# CLI Support
 
 Following command line tools are supported:
 

--- a/docs/cli/t4sanity.md
+++ b/docs/cli/t4sanity.md
@@ -59,11 +59,11 @@ $ t4sanity <DATA_ROOT>
   STR008: ✅
   ...
 
-+-----------+---------+---------+-------+---------+----------+-------+----------+
-| DatasetID | Version | Status  | Rules | Success | Failures | Skips | Warnings |
-+-----------+---------+---------+-------+---------+----------+-------+----------+
-| dataset1  |         | SUCCESS |  49   |   43    |    0     |   2   |    4     |
-+-----------+---------+---------+-------+---------+----------+-------+----------+
++-----------+---------+--------+--------+---------+----------+
+| DatasetID | Version | Passed | Failed | Skipped | Warnings |
++-----------+---------+--------+--------+---------+----------+
+| dataset1  |         |   49   |   0    |    2    |    3     |
++-----------+---------+--------+--------+---------+----------+
 ```
 
 ### Dump Results as JSON
@@ -86,8 +86,8 @@ Then a JSON file named `result.json` will be generated as follows:
         "name": "<RuleName: str>",
         "severity": "<WARNING/ERROR: str>",
         "description": "<Description: str>",
-        "status": "<SUCCESS/FAILURE/SKIPPED: str>",
-        "reasons": "<[<Reason1>, <Reason2>, ...]: [str; N] | null>" // Failure or skipped reasons, null if success
+        "status": "<PASSED/FAILED/SKIPPED: str>",
+        "reasons": "<[<Reason1>, <Reason2>, ...]: [str; N] | null>" // Failed or skipped reasons, null if passed
     },
   ]
 }

--- a/t4_devkit/cli/sanity.py
+++ b/t4_devkit/cli/sanity.py
@@ -56,7 +56,7 @@ def main(
         serialized = serialize_dataclass(result)
         save_json(serialized, output)
 
-    if result.is_success(strict=strict):
+    if result.is_passed(strict=strict):
         sys.exit(0)
     else:
         sys.exit(1)


### PR DESCRIPTION
## What

This pull request standardizes the terminology used for reporting rule outcomes in the sanity checking module, changing from "SUCCESS/FAILURE" to "PASSED/FAILED". It updates both the codebase and documentation to reflect this new terminology, and simplifies the printed summary output. The changes improve clarity and consistency across the code, output, and documentation.

**Terminology and Status Standardization**
* Renamed `Status.SUCCESS`/`Status.FAILURE` to `Status.PASSED`/`Status.FAILED` in `t4_devkit/sanity/result.py`, and updated all related logic, methods, and assertions to use the new terms (`is_success` → `is_passed`, `is_failure` → `is_failed`, etc.). [[1]](diffhunk://#diff-741fd8d81c4eb50acb97230c316e718323d42bf84302c2bac9dfbfa72c1e263eL20-R21) [[2]](diffhunk://#diff-741fd8d81c4eb50acb97230c316e718323d42bf84302c2bac9dfbfa72c1e263eL49-R65) [[3]](diffhunk://#diff-741fd8d81c4eb50acb97230c316e718323d42bf84302c2bac9dfbfa72c1e263eL82-R84) [[4]](diffhunk://#diff-741fd8d81c4eb50acb97230c316e718323d42bf84302c2bac9dfbfa72c1e263eL125-R134) [[5]](diffhunk://#diff-741fd8d81c4eb50acb97230c316e718323d42bf84302c2bac9dfbfa72c1e263eL147-R147)
* Updated the CLI exit condition in `t4_devkit/cli/sanity.py` to use `is_passed` instead of `is_success`.

**Summary Output and Documentation Updates**
* Simplified and updated the printed summary table in `t4_devkit/sanity/result.py` to use the new "Passed", "Failed", "Skipped", and "Warnings" columns, removing the old "Status", "Rules", and "Success/Failures/Skips" columns.
* Updated the CLI documentation in `docs/cli/t4sanity.md` to show the new summary table format and changed the status values in the JSON output example from "SUCCESS/FAILURE" to "PASSED/FAILED". [[1]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50L62-R66) [[2]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50L89-R90)