### PR TITLE
refactor: declare rule-id as class variable

### DIFF
--- a/t4_devkit/sanity/checker.py
+++ b/t4_devkit/sanity/checker.py
@@ -35,12 +35,10 @@ class Severity(str, Enum):
 class Checker(ABC):
     """Base class for sanity checkers."""
 
+    id: RuleID
     name: RuleName
     description: str
     severity: Severity
-
-    def __init__(self, id: RuleID) -> None:
-        self.id = id
 
     def __call__(self, context: SanityContext) -> Report:
         match self.can_skip(context):

--- a/t4_devkit/sanity/format/base.py
+++ b/t4_devkit/sanity/format/base.py
@@ -20,6 +20,7 @@ class FieldTypeChecker(Checker):
     """Base class for format checkers.
 
     Attributes:
+        id (RuleID): The ID of the rule.
         name (RuleName): The name of the rule.
         severity (Severity): The severity of the rule.
         description (str): The description of the rule.

--- a/t4_devkit/sanity/format/fmt001.py
+++ b/t4_devkit/sanity/format/fmt001.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT001"]
 
 
-@CHECKERS.register(RuleID("FMT001"))
+@CHECKERS.register()
 class FMT001(FieldTypeChecker):
     """A checker of FMT001."""
 
+    id = RuleID("FMT001")
     name = RuleName("attribute-field")
     severity = Severity.ERROR
     description = "All types of 'Attribute' fields are valid."

--- a/t4_devkit/sanity/format/fmt002.py
+++ b/t4_devkit/sanity/format/fmt002.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT002"]
 
 
-@CHECKERS.register(RuleID("FMT002"))
+@CHECKERS.register()
 class FMT002(FieldTypeChecker):
     """A checker of FMT002."""
 
+    id = RuleID("FMT002")
     name = RuleName("calibrated-sensor-field")
     severity = Severity.ERROR
     description = "All types of 'CalibratedSensor' fields are valid."

--- a/t4_devkit/sanity/format/fmt003.py
+++ b/t4_devkit/sanity/format/fmt003.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT003"]
 
 
-@CHECKERS.register(RuleID("FMT003"))
+@CHECKERS.register()
 class FMT003(FieldTypeChecker):
     """A checker of FMT003."""
 
+    id = RuleID("FMT003")
     name = RuleName("category-field")
     severity = Severity.ERROR
     description = "All types of 'Category' fields are valid."

--- a/t4_devkit/sanity/format/fmt004.py
+++ b/t4_devkit/sanity/format/fmt004.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT004"]
 
 
-@CHECKERS.register(RuleID("FMT004"))
+@CHECKERS.register()
 class FMT004(FieldTypeChecker):
     """A checker of FMT004."""
 
+    id = RuleID("FMT004")
     name = RuleName("ego-pose-field")
     severity = Severity.ERROR
     description = "All types of 'EgoPose' fields are valid."

--- a/t4_devkit/sanity/format/fmt005.py
+++ b/t4_devkit/sanity/format/fmt005.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT005"]
 
 
-@CHECKERS.register(RuleID("FMT005"))
+@CHECKERS.register()
 class FMT005(FieldTypeChecker):
     """A checker of FMT005."""
 
+    id = RuleID("FMT005")
     name = RuleName("instance-field")
     severity = Severity.ERROR
     description = "All types of 'Instance' fields are valid."

--- a/t4_devkit/sanity/format/fmt006.py
+++ b/t4_devkit/sanity/format/fmt006.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT006"]
 
 
-@CHECKERS.register(RuleID("FMT006"))
+@CHECKERS.register()
 class FMT006(FieldTypeChecker):
     """A checker of FMT006."""
 
+    id = RuleID("FMT006")
     name = RuleName("log-field")
     severity = Severity.ERROR
     description = "All types of 'Log' fields are valid."

--- a/t4_devkit/sanity/format/fmt007.py
+++ b/t4_devkit/sanity/format/fmt007.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT007"]
 
 
-@CHECKERS.register(RuleID("FMT007"))
+@CHECKERS.register()
 class FMT007(FieldTypeChecker):
     """A checker of FMT007."""
 
+    id = RuleID("FMT007")
     name = RuleName("map-field")
     severity = Severity.ERROR
     description = "All types of 'Map' fields are valid."

--- a/t4_devkit/sanity/format/fmt008.py
+++ b/t4_devkit/sanity/format/fmt008.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT008"]
 
 
-@CHECKERS.register(RuleID("FMT008"))
+@CHECKERS.register()
 class FMT008(FieldTypeChecker):
     """A checker of FMT008."""
 
+    id = RuleID("FMT008")
     name = RuleName("sample-field")
     severity = Severity.ERROR
     description = "All types of 'Sample' fields are valid."

--- a/t4_devkit/sanity/format/fmt009.py
+++ b/t4_devkit/sanity/format/fmt009.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT009"]
 
 
-@CHECKERS.register(RuleID("FMT009"))
+@CHECKERS.register()
 class FMT009(FieldTypeChecker):
     """A checker of FMT009."""
 
+    id = RuleID("FMT009")
     name = RuleName("sample-annotation-field")
     severity = Severity.ERROR
     description = "All types of 'SampleAnnotation' fields are valid."

--- a/t4_devkit/sanity/format/fmt010.py
+++ b/t4_devkit/sanity/format/fmt010.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT010"]
 
 
-@CHECKERS.register(RuleID("FMT010"))
+@CHECKERS.register()
 class FMT010(FieldTypeChecker):
     """A checker of FMT010."""
 
+    id = RuleID("FMT010")
     name = RuleName("sample-data-field")
     severity = Severity.ERROR
     description = "All types of 'SampleData' fields are valid."

--- a/t4_devkit/sanity/format/fmt011.py
+++ b/t4_devkit/sanity/format/fmt011.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT011"]
 
 
-@CHECKERS.register(RuleID("FMT011"))
+@CHECKERS.register()
 class FMT011(FieldTypeChecker):
     """A checker of FMT011."""
 
+    id = RuleID("FMT011")
     name = RuleName("scene-field")
     severity = Severity.ERROR
     description = "All types of 'Scene' fields are valid."

--- a/t4_devkit/sanity/format/fmt012.py
+++ b/t4_devkit/sanity/format/fmt012.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT012"]
 
 
-@CHECKERS.register(RuleID("FMT012"))
+@CHECKERS.register()
 class FMT012(FieldTypeChecker):
     """A checker of FMT012."""
 
+    id = RuleID("FMT012")
     name = RuleName("sensor-field")
     severity = Severity.ERROR
     description = "All types of 'Sensor' fields are valid."

--- a/t4_devkit/sanity/format/fmt013.py
+++ b/t4_devkit/sanity/format/fmt013.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT013"]
 
 
-@CHECKERS.register(RuleID("FMT013"))
+@CHECKERS.register()
 class FMT013(FieldTypeChecker):
     """A checker of FMT013."""
 
+    id = RuleID("FMT013")
     name = RuleName("visibility-field")
     severity = Severity.ERROR
     description = "All types of 'Visibility' fields are valid."

--- a/t4_devkit/sanity/format/fmt014.py
+++ b/t4_devkit/sanity/format/fmt014.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT014"]
 
 
-@CHECKERS.register(RuleID("FMT014"))
+@CHECKERS.register()
 class FMT014(FieldTypeChecker):
     """A checker of FMT014."""
 
+    id = RuleID("FMT014")
     name = RuleName("lidarseg-field")
     severity = Severity.ERROR
     description = "All types of 'LidarSeg' fields are valid."

--- a/t4_devkit/sanity/format/fmt015.py
+++ b/t4_devkit/sanity/format/fmt015.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT015"]
 
 
-@CHECKERS.register(RuleID("FMT015"))
+@CHECKERS.register()
 class FMT015(FieldTypeChecker):
     """A checker of FMT015."""
 
+    id = RuleID("FMT015")
     name = RuleName("object-ann-field")
     severity = Severity.ERROR
     description = "All types of 'ObjectAnn' fields are valid."

--- a/t4_devkit/sanity/format/fmt016.py
+++ b/t4_devkit/sanity/format/fmt016.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT016"]
 
 
-@CHECKERS.register(RuleID("FMT016"))
+@CHECKERS.register()
 class FMT016(FieldTypeChecker):
     """A checker of FMT016."""
 
+    id = RuleID("FMT016")
     name = RuleName("surface-ann-field")
     severity = Severity.ERROR
     description = "All types of 'SurfaceAnn' fields are valid."

--- a/t4_devkit/sanity/format/fmt017.py
+++ b/t4_devkit/sanity/format/fmt017.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT017"]
 
 
-@CHECKERS.register(RuleID("FMT017"))
+@CHECKERS.register()
 class FMT017(FieldTypeChecker):
     """A checker of FMT017."""
 
+    id = RuleID("FMT017")
     name = RuleName("keypoint-field")
     severity = Severity.ERROR
     description = "All types of 'Keypoint' fields are valid."

--- a/t4_devkit/sanity/format/fmt018.py
+++ b/t4_devkit/sanity/format/fmt018.py
@@ -9,10 +9,11 @@ from .base import FieldTypeChecker
 __all__ = ["FMT018"]
 
 
-@CHECKERS.register(RuleID("FMT018"))
+@CHECKERS.register()
 class FMT018(FieldTypeChecker):
     """A checker of FMT018."""
 
+    id = RuleID("FMT018")
     name = RuleName("vehicle-state-field")
     severity = Severity.ERROR
     description = "All types of 'VehicleState' fields are valid."

--- a/t4_devkit/sanity/record/base.py
+++ b/t4_devkit/sanity/record/base.py
@@ -19,6 +19,7 @@ class RecordCountChecker(Checker):
     """Base class for record count checkers.
 
     Attributes:
+        id (RuleID): The ID of the rule.
         name (RuleName): The name of the rule.
         severity (Severity): The severity of the rule.
         description (str): The description of the rule.

--- a/t4_devkit/sanity/record/rec001.py
+++ b/t4_devkit/sanity/record/rec001.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC001"]
 
 
-@CHECKERS.register(RuleID("REC001"))
+@CHECKERS.register()
 class REC001(RecordCountChecker):
     """A checker of REC001."""
 
+    id = RuleID("REC001")
     name = RuleName("scene-single")
     severity = Severity.ERROR
     description = "'Scene' record is a single."

--- a/t4_devkit/sanity/record/rec002.py
+++ b/t4_devkit/sanity/record/rec002.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC002"]
 
 
-@CHECKERS.register(RuleID("REC002"))
+@CHECKERS.register()
 class REC002(RecordCountChecker):
     """A checker of REC002."""
 
+    id = RuleID("REC002")
     name = RuleName("sample-not-empty")
     severity = Severity.ERROR
     description = "'Sample' record is not empty."

--- a/t4_devkit/sanity/record/rec003.py
+++ b/t4_devkit/sanity/record/rec003.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC003"]
 
 
-@CHECKERS.register(RuleID("REC003"))
+@CHECKERS.register()
 class REC003(RecordCountChecker):
     """A checker of REC003."""
 
+    id = RuleID("REC003")
     name = RuleName("sample-data-not-empty")
     severity = Severity.ERROR
     description = "'SampleData' record is not empty."

--- a/t4_devkit/sanity/record/rec004.py
+++ b/t4_devkit/sanity/record/rec004.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC004"]
 
 
-@CHECKERS.register(RuleID("REC004"))
+@CHECKERS.register()
 class REC004(RecordCountChecker):
     """A checker of REC004."""
 
+    id = RuleID("REC004")
     name = RuleName("ego-pose-not-empty")
     severity = Severity.ERROR
     description = "'EgoPose' record is not empty."

--- a/t4_devkit/sanity/record/rec005.py
+++ b/t4_devkit/sanity/record/rec005.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC005"]
 
 
-@CHECKERS.register(RuleID("REC005"))
+@CHECKERS.register()
 class REC005(RecordCountChecker):
     """A checker of REC005."""
 
+    id = RuleID("REC005")
     name = RuleName("calibrated-sensor-not-empty")
     severity = Severity.ERROR
     description = "'CalibratedSensor' record is not empty."

--- a/t4_devkit/sanity/record/rec006.py
+++ b/t4_devkit/sanity/record/rec006.py
@@ -10,10 +10,11 @@ from .base import RecordCountChecker
 __all__ = ["REC006"]
 
 
-@CHECKERS.register(RuleID("REC006"))
+@CHECKERS.register()
 class REC006(RecordCountChecker):
     """A checker of REC006."""
 
+    id = RuleID("REC006")
     name = RuleName("instance-not-empty")
     severity = Severity.ERROR
     description = "'Instance' record is not empty."

--- a/t4_devkit/sanity/reference/base.py
+++ b/t4_devkit/sanity/reference/base.py
@@ -18,6 +18,7 @@ class RecordReferenceChecker(Checker):
     """Base class for record reference checkers.
 
     Attributes:
+        id (RuleID): The ID of the rule.
         name (RuleName): The name of the rule.
         severity (Severity): The severity of the rule.
         description (str): The description of the rule.

--- a/t4_devkit/sanity/reference/ref001.py
+++ b/t4_devkit/sanity/reference/ref001.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF001"]
 
 
-@CHECKERS.register(RuleID("REF001"))
+@CHECKERS.register()
 class REF001(RecordReferenceChecker):
     """A checker of REF001."""
 
+    id = RuleID("REF001")
     name = RuleName("scene-to-log")
     severity = Severity.ERROR
     description = "'Scene.log_token' refers to 'Log' record."

--- a/t4_devkit/sanity/reference/ref002.py
+++ b/t4_devkit/sanity/reference/ref002.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF002"]
 
 
-@CHECKERS.register(RuleID("REF002"))
+@CHECKERS.register()
 class REF002(RecordReferenceChecker):
     """A checker of REF002."""
 
+    id = RuleID("REF002")
     name = RuleName("scene-to-first-sample")
     severity = Severity.ERROR
     description = "'Scene.first_sample_token' refers to 'Sample' record."

--- a/t4_devkit/sanity/reference/ref003.py
+++ b/t4_devkit/sanity/reference/ref003.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF003"]
 
 
-@CHECKERS.register(RuleID("REF003"))
+@CHECKERS.register()
 class REF003(RecordReferenceChecker):
     """A checker of REF003."""
 
+    id = RuleID("REF003")
     name = RuleName("scene-to-last-sample")
     severity = Severity.ERROR
     description = "'Scene.last_sample_token' refers to 'Sample' record."

--- a/t4_devkit/sanity/reference/ref004.py
+++ b/t4_devkit/sanity/reference/ref004.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF004"]
 
 
-@CHECKERS.register(RuleID("REF004"))
+@CHECKERS.register()
 class REF004(RecordReferenceChecker):
     """A checker of REF004."""
 
+    id = RuleID("REF004")
     name = RuleName("sample-to-scene")
     severity = Severity.ERROR
     description = "'Sample.scene_token' refers to 'Scene' record."

--- a/t4_devkit/sanity/reference/ref005.py
+++ b/t4_devkit/sanity/reference/ref005.py
@@ -11,10 +11,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF005"]
 
 
-@CHECKERS.register(RuleID("REF005"))
+@CHECKERS.register()
 class REF005(RecordReferenceChecker):
     """A checker of REF005."""
 
+    id = RuleID("REF005")
     name = RuleName("sample-data-to-sample")
     severity = Severity.ERROR
     description = "'SampleData.sample_token' refers to 'Sample' record."

--- a/t4_devkit/sanity/reference/ref006.py
+++ b/t4_devkit/sanity/reference/ref006.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF006"]
 
 
-@CHECKERS.register(RuleID("REF006"))
+@CHECKERS.register()
 class REF006(RecordReferenceChecker):
     """A checker of REF006."""
 
+    id = RuleID("REF006")
     name = RuleName("sample-data-to-ego-pose")
     severity = Severity.ERROR
     description = "'SampleData.ego_pose_token' refers to 'EgoPose' record."

--- a/t4_devkit/sanity/reference/ref007.py
+++ b/t4_devkit/sanity/reference/ref007.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF007"]
 
 
-@CHECKERS.register(RuleID("REF007"))
+@CHECKERS.register()
 class REF007(RecordReferenceChecker):
     """A checker of REF007."""
 
+    id = RuleID("REF007")
     name = RuleName("sample-data-to-calibrated-sensor")
     severity = Severity.ERROR
     description = "'SampleData.calibrated_sensor_token' refers to 'CalibratedSensor' record."

--- a/t4_devkit/sanity/reference/ref008.py
+++ b/t4_devkit/sanity/reference/ref008.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF008"]
 
 
-@CHECKERS.register(RuleID("REF008"))
+@CHECKERS.register()
 class REF008(RecordReferenceChecker):
     """A checker of REF008."""
 
+    id = RuleID("REF008")
     name = RuleName("calibrated-sensor-to-sensor")
     severity = Severity.ERROR
     description = "'CalibratedSensor.sensor_token' refers to 'Sensor' record."

--- a/t4_devkit/sanity/reference/ref009.py
+++ b/t4_devkit/sanity/reference/ref009.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF009"]
 
 
-@CHECKERS.register(RuleID("REF009"))
+@CHECKERS.register()
 class REF009(RecordReferenceChecker):
     """A checker of REF009."""
 
+    id = RuleID("REF009")
     name = RuleName("instance-to-category")
     severity = Severity.ERROR
     description = "'Instance.category_token' refers to 'Category' record."

--- a/t4_devkit/sanity/reference/ref010.py
+++ b/t4_devkit/sanity/reference/ref010.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF010"]
 
 
-@CHECKERS.register(RuleID("REF010"))
+@CHECKERS.register()
 class REF010(RecordReferenceChecker):
     """A checker of REF010."""
 
+    id = RuleID("REF010")
     name = RuleName("instance-to-first-sample-annotation")
     severity = Severity.ERROR
     description = "'Instance.first_annotation_token' refers to 'SampleAnnotation' record."

--- a/t4_devkit/sanity/reference/ref011.py
+++ b/t4_devkit/sanity/reference/ref011.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF011"]
 
 
-@CHECKERS.register(RuleID("REF011"))
+@CHECKERS.register()
 class REF011(RecordReferenceChecker):
     """A checker of REF011."""
 
+    id = RuleID("REF011")
     name = RuleName("instance-to-last-sample-annotation")
     severity = Severity.ERROR
     description = "'Instance.last_annotation_token' refers to 'SampleAnnotation' record."

--- a/t4_devkit/sanity/reference/ref012.py
+++ b/t4_devkit/sanity/reference/ref012.py
@@ -9,10 +9,11 @@ from .base import RecordReferenceChecker
 __all__ = ["REF012"]
 
 
-@CHECKERS.register(RuleID("REF012"))
+@CHECKERS.register()
 class REF012(RecordReferenceChecker):
     """A checker of REF012."""
 
+    id = RuleID("REF012")
     name = RuleName("lidarset-to-sample-data")
     severity = Severity.ERROR
     description = "'LidarSeg.sample_data_token' refers to 'SampleData' record."

--- a/t4_devkit/sanity/reference/ref013.py
+++ b/t4_devkit/sanity/reference/ref013.py
@@ -17,10 +17,11 @@ if TYPE_CHECKING:
 __all__ = ["REF013"]
 
 
-@CHECKERS.register(RuleID("REF013"))
+@CHECKERS.register()
 class REF013(FileReferenceChecker):
     """A checker of REF013."""
 
+    id = RuleID("REF013")
     name = RuleName("sample-data-filename-presence")
     severity = Severity.ERROR
     description = "'SampleData.filename' exists."

--- a/t4_devkit/sanity/reference/ref014.py
+++ b/t4_devkit/sanity/reference/ref014.py
@@ -17,10 +17,11 @@ if TYPE_CHECKING:
 __all__ = ["REF014"]
 
 
-@CHECKERS.register(RuleID("REF014"))
+@CHECKERS.register()
 class REF014(FileReferenceChecker):
     """A checker of REF014."""
 
+    id = RuleID("REF014")
     name = RuleName("sample-data-filename-presence")
     severity = Severity.ERROR
     description = "'SampleData.filename' exists."

--- a/t4_devkit/sanity/reference/ref015.py
+++ b/t4_devkit/sanity/reference/ref015.py
@@ -17,10 +17,11 @@ if TYPE_CHECKING:
 __all__ = ["REF015"]
 
 
-@CHECKERS.register(RuleID("REF015"))
+@CHECKERS.register()
 class REF015(FileReferenceChecker):
     """A checker of REF015."""
 
+    id = RuleID("REF015")
     name = RuleName("lidarseg-filename-presence")
     severity = Severity.ERROR
     description = "'LidarSeg.filename' exists."

--- a/t4_devkit/sanity/registry.py
+++ b/t4_devkit/sanity/registry.py
@@ -37,37 +37,37 @@ class RuleGroup(Enum):
 
 
 class CheckerRegistry(dict[RuleGroup, dict[RuleID, type[Checker]]]):
-    def register(self, id: RuleID) -> Callable:
+    def register(self) -> Callable:
         """Register a checker class.
-
-        Args:
-            id (RuleID): The ID of the rule.
 
         Returns:
             A decorator function that registers the checker class.
         """
-        group = RuleGroup.to_group(id)
-
-        if group is None:
-            raise ValueError(f"'{id}' doesn't belong to any rule groups: {RuleGroup.values()}")
 
         def _register_decorator(module: type[Checker]) -> type[Checker]:
-            self._add_module(module, group, id)
+            self._add_module(module)
             return module
 
         return _register_decorator
 
-    def _add_module(self, module: type[Checker], group: RuleGroup, id: RuleID) -> None:
+    def _add_module(self, module: type[Checker]) -> None:
         if not inspect.isclass(module):
             raise TypeError(f"module must be a class, but got {type(module)}.")
+
+        group = RuleGroup.to_group(module.id)
+
+        if group is None:
+            raise ValueError(
+                f"'{module.id}' doesn't belong to any rule groups: {RuleGroup.values()}"
+            )
 
         if group not in self:
             self[group] = {}
 
-        if id in self[group]:
-            raise ValueError(f"'{id}' has already been registered.")
+        if module.id in self[group]:
+            raise ValueError(f"'{module.id}' has already been registered.")
 
-        self[group][id] = module
+        self[group][module.id] = module
 
     def build(self, excludes: Sequence[str] | None = None) -> list[Checker]:
         """Build a list of checkers from the registry.
@@ -82,7 +82,7 @@ class CheckerRegistry(dict[RuleGroup, dict[RuleID, type[Checker]]]):
             excludes = []
 
         return [
-            checker(id)
+            checker()
             for group, values in self.items()
             for id, checker in values.items()
             if id not in excludes and group.value not in excludes

--- a/t4_devkit/sanity/structure/str001.py
+++ b/t4_devkit/sanity/structure/str001.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR001"]
 
 
-@CHECKERS.register(RuleID("STR001"))
+@CHECKERS.register()
 class STR001(Checker):
     """A checker of STR001."""
 
+    id = RuleID("STR001")
     name = RuleName("version-dir-presence")
     severity = Severity.WARNING
     description = "'version/' directory exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str002.py
+++ b/t4_devkit/sanity/structure/str002.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR002"]
 
 
-@CHECKERS.register(RuleID("STR002"))
+@CHECKERS.register()
 class STR002(Checker):
     """A checker of STR002."""
 
+    id = RuleID("STR002")
     name = RuleName("annotation-dir-presence")
     severity = Severity.ERROR
     description = "'annotation/' directory exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str003.py
+++ b/t4_devkit/sanity/structure/str003.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR003"]
 
 
-@CHECKERS.register(RuleID("STR003"))
+@CHECKERS.register()
 class STR003(Checker):
     """A checker of STR003."""
 
+    id = RuleID("STR003")
     name = RuleName("data-dir-presence")
     severity = Severity.ERROR
     description = "'data/' directory exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str004.py
+++ b/t4_devkit/sanity/structure/str004.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR004"]
 
 
-@CHECKERS.register(RuleID("STR004"))
+@CHECKERS.register()
 class STR004(Checker):
     """A checker of STR004."""
 
+    id = RuleID("STR004")
     name = RuleName("map-dir-presence")
     severity = Severity.WARNING
     description = "'map/' directory exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str005.py
+++ b/t4_devkit/sanity/structure/str005.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR005"]
 
 
-@CHECKERS.register(RuleID("STR005"))
+@CHECKERS.register()
 class STR005(Checker):
     """A checker of STR005."""
 
+    id = RuleID("STR005")
     name = RuleName("bag-dir-presence")
     severity = Severity.WARNING
     description = "'input_bag/' directory exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str006.py
+++ b/t4_devkit/sanity/structure/str006.py
@@ -15,10 +15,11 @@ if TYPE_CHECKING:
 __all__ = ["STR006"]
 
 
-@CHECKERS.register(RuleID("STR006"))
+@CHECKERS.register()
 class STR006(Checker):
     """A checker of STR006."""
 
+    id = RuleID("STR006")
     name = RuleName("status-json-presence")
     severity = Severity.WARNING
     description = "'status.json' file exists under the dataset root directory."

--- a/t4_devkit/sanity/structure/str007.py
+++ b/t4_devkit/sanity/structure/str007.py
@@ -17,10 +17,11 @@ if TYPE_CHECKING:
 __all__ = ["STR007"]
 
 
-@CHECKERS.register(RuleID("STR007"))
+@CHECKERS.register()
 class STR007(Checker):
     """A checker of STR007."""
 
+    id = RuleID("STR007")
     name = RuleName("schema-file-presence")
     severity = Severity.ERROR
     description = "Mandatory schema JSON files exist under the `annotation/` directory."

--- a/t4_devkit/sanity/structure/str008.py
+++ b/t4_devkit/sanity/structure/str008.py
@@ -14,10 +14,11 @@ if TYPE_CHECKING:
 __all__ = ["STR008"]
 
 
-@CHECKERS.register(RuleID("STR008"))
+@CHECKERS.register()
 class STR008(Checker):
     """A checker of STR008."""
 
+    id = RuleID("STR008")
     name = RuleName("lanelet-file-presence")
     severity = Severity.WARNING
     description = "'lanelet2_map.osm' file exists under the 'map/' directory."

--- a/t4_devkit/sanity/structure/str009.py
+++ b/t4_devkit/sanity/structure/str009.py
@@ -14,10 +14,11 @@ if TYPE_CHECKING:
 __all__ = ["STR009"]
 
 
-@CHECKERS.register(RuleID("STR009"))
+@CHECKERS.register()
 class STR009(Checker):
     """A checker of STR009."""
 
+    id = RuleID("STR009")
     name = RuleName("pointcloud-map-dir-presence")
     severity = Severity.WARNING
     description = "'pointcloud_map.pcd' directory exists under the 'map/' directory."

--- a/t4_devkit/sanity/tier4/tiv001.py
+++ b/t4_devkit/sanity/tier4/tiv001.py
@@ -18,10 +18,11 @@ if TYPE_CHECKING:
 __all__ = ["TIV001"]
 
 
-@CHECKERS.register(RuleID("TIV001"))
+@CHECKERS.register()
 class TIV001(Checker):
     """A checker for TIV001."""
 
+    id = RuleID("TIV001")
     name = RuleName("load-tier4")
     severity = Severity.ERROR
     description = "Ensure 'Tier4' instance is loaded successfully."


### PR DESCRIPTION
## What

This pull request refactors the way rule IDs are assigned and registered for format checkers in the `t4_devkit.sanity` module. Instead of passing the rule ID as an argument to the `@CHECKERS.register` decorator and the checker class constructor, each checker class now sets its `id` as a class attribute. The decorator is also simplified to not require the rule ID as an argument. This makes the code more consistent and easier to maintain.

Key changes include:

**Refactoring rule ID assignment and registration:**

* Removed the `id` parameter from the `@CHECKERS.register` decorator in all checker classes and instead set the `id` as a class attribute within each checker class, such as `FMT001` through `FMT018`. [[1]](diffhunk://#diff-5f1850be7004381c299687b23e1cacfa1c2349e389f25d26ce77ae4a5901ec73L12-R16) [[2]](diffhunk://#diff-f26a3c22579bedc628372ebdb8bbd2bf0755194b523c5e3c14c73f795aa6b348L12-R16) [[3]](diffhunk://#diff-7aeb57392e2b6d1f0a0058fa56101c5fd03f9dc84625893e6aae9576f8327027L12-R16) [[4]](diffhunk://#diff-caee1a335c9c1fdd91ed64c05a56d6f33a759bac1fdfe14991bd60eea1245acbL12-R16) [[5]](diffhunk://#diff-b9f9bfffd8abbf2fd0091b2d012ac2d06c1b163db3f04220d8a3d9150856a057L12-R16) [[6]](diffhunk://#diff-c79f6d29a183e08a4c2706f8a7f28f0d7b6e82fe1de599a553aff83a5adc750cL12-R16) [[7]](diffhunk://#diff-9614d8b92f2830318e92659918079e8cbded3ffa71f872fc0ef59d388b12240eL12-R16) [[8]](diffhunk://#diff-1711282f144e220d869558459d1ec541d5477168d5a2d11a8d2225aa67b496b4L12-R16) [[9]](diffhunk://#diff-f774a8571c63aa80f096b11010b0cae30072c6e8503b168308646bca825670f8L12-R16) [[10]](diffhunk://#diff-778e3938675a7ee2f504a6e7afb11e54ce9f5dbeb850cda66848c15b25c4fe4aL12-R16) [[11]](diffhunk://#diff-aeda807944ad813a9ae05e93ab4de82821803d6505d708bb7825761d7999154aL12-R16) [[12]](diffhunk://#diff-59b4abeba7c7f88d0fc209a37ba98bf3ea1b0f372914c331133d960b6b89a70eL12-R16) [[13]](diffhunk://#diff-27bdad29fe8d4f7b67ae2f6400269ea9a61b734ee73d4114d6f71fe23874da3cL12-R16) [[14]](diffhunk://#diff-7c5480432e92769c2dc9e21854dde4d9701aa805f6dfcc8b8fbf1dc93f34b807L12-R16) [[15]](diffhunk://#diff-ad905c5f0ad6fd2901021a5a3cc2e01203d7be7695b098d911ae8d2fc3c630d6L12-R16) [[16]](diffhunk://#diff-3bc2c3357d977bcf9ab57392252ba56842ad99c308ed73e002e8b3532aa4dc58L12-R16) [[17]](diffhunk://#diff-2e5f1c0b3c15c8ca7dce9c5a5244673ba5bfdc41d0cb4a894fc17b162a9f88faL12-R16) [[18]](diffhunk://#diff-ac7c59e955ca72929e654c20609375843bf4df4f758e97cb84114d599de9914eL12-R16)

* Updated the `Checker` base class to expect `id` as a class attribute rather than an instance attribute set in the constructor, and removed the `id` parameter from the constructor.

**Documentation improvements:**

* Updated the docstring for `FieldTypeChecker` to document the new `id` class attribute.