### PR TITLE
docs: update documents for sanity check

### DIFF
--- a/docs/apis/common.md
+++ b/docs/apis/common.md
@@ -7,8 +7,6 @@
 
 ::: t4_devkit.common.io
 
-::: t4_devkit.common.sanity
-
 ::: t4_devkit.common.serialize
 
 ::: t4_devkit.common.timestamp

--- a/docs/apis/sanity.md
+++ b/docs/apis/sanity.md
@@ -1,0 +1,8 @@
+# `sanity`
+
+<!-- prettier-ignore-start -->
+::: t4_devkit.sanity
+    options:
+        filters: ["!FMT*", "!REF*", "!REC*", "!STR*", "!TIV*"]
+        show_bases: false
+<!-- prettier-ignore-end -->

--- a/docs/cli/t4sanity.md
+++ b/docs/cli/t4sanity.md
@@ -61,9 +61,20 @@ $ t4sanity <DATA_ROOT>
 +-----------+---------+--------+--------+---------+----------+
 | DatasetID | Version | Passed | Failed | Skipped | Warnings |
 +-----------+---------+--------+--------+---------+----------+
-| dataset1  |         |   49   |   0    |    2    |    3     |
+| dataset1  |    0    |   49   |   0    |    2    |    3     |
 +-----------+---------+--------+--------+---------+----------+
 ```
+
+### Exit Status Logic
+
+`t4sanity` CLI returns the exit code based on the following conditions:
+
+| Condition                                                               | `--strict`        | Exit Code | Notes                                               |
+| ----------------------------------------------------------------------- | ----------------- | --------- | --------------------------------------------------- |
+| At least one `Severity.ERROR` rule failed                               | N/A               | 1         | Always fails the run                                |
+| At least one `Severity.WARNING` rule failed, no `Severity.ERROR` failed | `False` (default) | 0         | Run is considered successful, warnings are reported |
+| At least one `Severity.WARNING` rule failed, no `Severity.ERROR` failed | `True`            | 1         | Treat warnings as failures; exit with failure       |
+| All rules passed or skipped                                             | N/A               | 0         | Run is considered successful                        |
 
 ### Dump Results as JSON
 
@@ -91,6 +102,18 @@ Then a JSON file named `result.json` will be generated as follows:
   ]
 }
 ```
+
+Here is the description of the JSON format:
+
+- `dataset_id`: The ID of the dataset.
+- `version`: The version of the dataset.
+- `reports`: An array of rule reports.
+- `id`: The ID of the rule.
+- `name`: The name of the rule.
+- `severity`: How important a rule is.
+- `description`: A description of the rule.
+- `status`: What happened when it ran.
+- `reasons`: An array of reasons for failure or skipped rules, null if passed.
 
 ### Exclude Checks
 

--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -2,74 +2,74 @@
 
 ## Structure (`STR`)
 
-| ID       | Name                          | Severity | Description                                                          |
-| -------- | ----------------------------- | -------- | -------------------------------------------------------------------- |
-| `STR001` | `version-dir-presence`        | `Warn`   | `version/` directory exists under the dataset root directory.        |
-| `STR002` | `annotation-dir-presence`     | `Error`  | `annotation/` directory exists under the dataset root directory.     |
-| `STR003` | `data-dir-presence`           | `Error`  | `data/` directory exists under the dataset root directory.           |
-| `STR004` | `map-dir-presence`            | `Warn`   | `map/` directory exists under the dataset root directory.            |
-| `STR005` | `bag-dir-presence`            | `Warn`   | `input_bag/` directory exists under the dataset root directory.      |
-| `STR006` | `status-file-presence`        | `Warn`   | `status.json` file exists under the dataset root directory.          |
-| `STR007` | `schema-files-presence`       | `Error`  | Mandatory schema JSON files exist under the `annotation/` directory. |
-| `STR008` | `lanelet-file-presence`       | `Warn`   | `lanelet2_map.osm` file exists under the `map/` directory.           |
-| `STR009` | `pointcloud-map-dir-presence` | `Warn`   | `pointcloud_map.pcd` directory exists under the `map/` directory.    |
+| ID       | Name                          | Severity  | Description                                                          |
+| -------- | ----------------------------- | --------- | -------------------------------------------------------------------- |
+| `STR001` | `version-dir-presence`        | `WARNING` | `version/` directory exists under the dataset root directory.        |
+| `STR002` | `annotation-dir-presence`     | `ERROR`   | `annotation/` directory exists under the dataset root directory.     |
+| `STR003` | `data-dir-presence`           | `ERROR`   | `data/` directory exists under the dataset root directory.           |
+| `STR004` | `map-dir-presence`            | `WARNING` | `map/` directory exists under the dataset root directory.            |
+| `STR005` | `bag-dir-presence`            | `WARNING` | `input_bag/` directory exists under the dataset root directory.      |
+| `STR006` | `status-file-presence`        | `WARNING` | `status.json` file exists under the dataset root directory.          |
+| `STR007` | `schema-files-presence`       | `ERROR`   | Mandatory schema JSON files exist under the `annotation/` directory. |
+| `STR008` | `lanelet-file-presence`       | `WARNING` | `lanelet2_map.osm` file exists under the `map/` directory.           |
+| `STR009` | `pointcloud-map-dir-presence` | `WARNING` | `pointcloud_map.pcd` directory exists under the `map/` directory.    |
 
 ## Schema Record (`REC`)
 
 | ID       | Name                          | Severity | Description                             |
 | -------- | ----------------------------- | -------- | --------------------------------------- |
-| `REC001` | `scene-single`                | `Error`  | `Scene` record is a single.             |
-| `REC002` | `sample-not-empty`            | `Error`  | `Sample` record is not empty.           |
-| `REC003` | `sample-data-not-empty`       | `Error`  | `SampleData` record is not empty.       |
-| `REC004` | `ego-pose-not-empty`          | `Error`  | `EgoPose` record is not empty.          |
-| `REC005` | `calibrated-sensor-non-empty` | `Error`  | `CalibratedSensor` record is not empty. |
-| `REC006` | `instance-not-empty`          | `Error`  | `Instance` record is not empty.         |
+| `REC001` | `scene-single`                | `ERROR`  | `Scene` record is a single.             |
+| `REC002` | `sample-not-empty`            | `ERROR`  | `Sample` record is not empty.           |
+| `REC003` | `sample-data-not-empty`       | `ERROR`  | `SampleData` record is not empty.       |
+| `REC004` | `ego-pose-not-empty`          | `ERROR`  | `EgoPose` record is not empty.          |
+| `REC005` | `calibrated-sensor-non-empty` | `ERROR`  | `CalibratedSensor` record is not empty. |
+| `REC006` | `instance-not-empty`          | `ERROR`  | `Instance` record is not empty.         |
 
 ## Reference (`REF`)
 
 | ID       | Name                                  | Severity | Description                                                               |
 | -------- | ------------------------------------- | -------- | ------------------------------------------------------------------------- |
-| `REF001` | `scene-to-log`                        | `Error`  | `Scene.log_token` refers to `Log` record.                                 |
-| `REF002` | `scene-to-first-sample`               | `Error`  | `Scene.first_sample_token` refers to `Sample` record.                     |
-| `REF003` | `scene-to-last-sample`                | `Error`  | `Scene.last_sample_token` refers to `Sample` record.                      |
-| `REF004` | `sample-to-scene`                     | `Error`  | `Sample.scene_token` refers to `Scene` record.                            |
-| `REF005` | `sample-data-to-sample`               | `Error`  | `SampleData.sample_token` refers to `Sample` record.                      |
-| `REF006` | `sample-data-to-ego-pose`             | `Error`  | `SampleData.ego_pose_token` refers to `EgoPose` record.                   |
-| `REF007` | `sample-data-to-calibrated-sensor`    | `Error`  | `SampleData.calibrated_sensor_token` refers to `CalibratedSensor` record. |
-| `REF008` | `calibrated-sensor-to-sensor`         | `Error`  | `CalibratedSensor.sensor_token` refers to `Sensor` record.                |
-| `REF009` | `instance-to-category`                | `Error`  | `Instance.category_token` refers to `Category` record.                    |
-| `REF010` | `instance-to-first-sample-annotation` | `Error`  | `Instance.first_annotation_token` refers to `SampleAnnotation` record.    |
-| `REF011` | `instance-to-last-sample-annotation`  | `Error`  | `Instance.last_annotation_token` refers to `SampleAnnotation` record.     |
-| `REF012` | `lidarseg-to-sample-data`             | `Error`  | `LidarSeg.sample_data_token` refers to `SampleData` record.               |
-| `REF013` | `sample-data-filename-presence`       | `Error`  | `SampleData.filename` exists.                                             |
-| `REF014` | `sample-data-info-filename-presence`  | `Error`  | `SampleData.info_filename` exists if it is not `None`.                    |
-| `REF015` | `lidarseg-filename-presence`          | `Error`  | `LidarSeg.filename` exists if `lidarseg.json` exists.                     |
+| `REF001` | `scene-to-log`                        | `ERROR`  | `Scene.log_token` refers to `Log` record.                                 |
+| `REF002` | `scene-to-first-sample`               | `ERROR`  | `Scene.first_sample_token` refers to `Sample` record.                     |
+| `REF003` | `scene-to-last-sample`                | `ERROR`  | `Scene.last_sample_token` refers to `Sample` record.                      |
+| `REF004` | `sample-to-scene`                     | `ERROR`  | `Sample.scene_token` refers to `Scene` record.                            |
+| `REF005` | `sample-data-to-sample`               | `ERROR`  | `SampleData.sample_token` refers to `Sample` record.                      |
+| `REF006` | `sample-data-to-ego-pose`             | `ERROR`  | `SampleData.ego_pose_token` refers to `EgoPose` record.                   |
+| `REF007` | `sample-data-to-calibrated-sensor`    | `ERROR`  | `SampleData.calibrated_sensor_token` refers to `CalibratedSensor` record. |
+| `REF008` | `calibrated-sensor-to-sensor`         | `ERROR`  | `CalibratedSensor.sensor_token` refers to `Sensor` record.                |
+| `REF009` | `instance-to-category`                | `ERROR`  | `Instance.category_token` refers to `Category` record.                    |
+| `REF010` | `instance-to-first-sample-annotation` | `ERROR`  | `Instance.first_annotation_token` refers to `SampleAnnotation` record.    |
+| `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `Instance.last_annotation_token` refers to `SampleAnnotation` record.     |
+| `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `LidarSeg.sample_data_token` refers to `SampleData` record.               |
+| `REF013` | `sample-data-filename-presence`       | `ERROR`  | `SampleData.filename` exists.                                             |
+| `REF014` | `sample-data-info-filename-presence`  | `ERROR`  | `SampleData.info_filename` exists if it is not `None`.                    |
+| `REF015` | `lidarseg-filename-presence`          | `ERROR`  | `LidarSeg.filename` exists if `lidarseg.json` exists.                     |
 
 ## Format (`FMT`)
 
 | ID       | Name                      | Severity | Description                                       |
 | -------- | ------------------------- | -------- | ------------------------------------------------- |
-| `FMT001` | `attribute-field`         | `Error`  | All types of `Attribute` fields are valid.        |
-| `FMT002` | `calibrated-sensor-field` | `Error`  | All types of `CalibratedSensor` fields are valid. |
-| `FMT003` | `category-field`          | `Error`  | All types of `Category` fields are valid.         |
-| `FMT004` | `ego-pose-field`          | `Error`  | All types of `EgoPose` fields are valid.          |
-| `FMT005` | `instance-field`          | `Error`  | All types of `Instance` fields are valid.         |
-| `FMT006` | `log-field`               | `Error`  | All types of `Log` fields are valid.              |
-| `FMT007` | `map-field`               | `Error`  | All types of `Map` fields are valid.              |
-| `FMT008` | `sample-field`            | `Error`  | All types of `Sample` fields are valid.           |
-| `FMT009` | `sample-annotation-field` | `Error`  | All types of `SampleAnnotation` fields are valid. |
-| `FMT010` | `sample-data-field`       | `Error`  | All types of `SampleData` fields are valid.       |
-| `FMT011` | `scene-field`             | `Error`  | All types of `Scene` fields are valid.            |
-| `FMT012` | `sensor-field`            | `Error`  | All types of `Sensor` fields are valid.           |
-| `FMT013` | `visibility-field`        | `Error`  | All types of `Visibility` fields are valid.       |
-| `FMT014` | `lidarseg-field`          | `Error`  | All types of `Lidarseg` fields are valid.         |
-| `FMT015` | `object-ann-field`        | `Error`  | All types of `ObjectAnn` fields are valid.        |
-| `FMT016` | `surface-ann-field`       | `Error`  | All types of `SurfaceAnn` fields are valid.       |
-| `FMT017` | `keypoint-field`          | `Error`  | All types of `Keypoint` fields are valid.         |
-| `FMT018` | `vehicle-state-field`     | `Error`  | All types of `VehicleState` fields are valid.     |
+| `FMT001` | `attribute-field`         | `ERROR`  | All types of `Attribute` fields are valid.        |
+| `FMT002` | `calibrated-sensor-field` | `ERROR`  | All types of `CalibratedSensor` fields are valid. |
+| `FMT003` | `category-field`          | `ERROR`  | All types of `Category` fields are valid.         |
+| `FMT004` | `ego-pose-field`          | `ERROR`  | All types of `EgoPose` fields are valid.          |
+| `FMT005` | `instance-field`          | `ERROR`  | All types of `Instance` fields are valid.         |
+| `FMT006` | `log-field`               | `ERROR`  | All types of `Log` fields are valid.              |
+| `FMT007` | `map-field`               | `ERROR`  | All types of `Map` fields are valid.              |
+| `FMT008` | `sample-field`            | `ERROR`  | All types of `Sample` fields are valid.           |
+| `FMT009` | `sample-annotation-field` | `ERROR`  | All types of `SampleAnnotation` fields are valid. |
+| `FMT010` | `sample-data-field`       | `ERROR`  | All types of `SampleData` fields are valid.       |
+| `FMT011` | `scene-field`             | `ERROR`  | All types of `Scene` fields are valid.            |
+| `FMT012` | `sensor-field`            | `ERROR`  | All types of `Sensor` fields are valid.           |
+| `FMT013` | `visibility-field`        | `ERROR`  | All types of `Visibility` fields are valid.       |
+| `FMT014` | `lidarseg-field`          | `ERROR`  | All types of `Lidarseg` fields are valid.         |
+| `FMT015` | `object-ann-field`        | `ERROR`  | All types of `ObjectAnn` fields are valid.        |
+| `FMT016` | `surface-ann-field`       | `ERROR`  | All types of `SurfaceAnn` fields are valid.       |
+| `FMT017` | `keypoint-field`          | `ERROR`  | All types of `Keypoint` fields are valid.         |
+| `FMT018` | `vehicle-state-field`     | `ERROR`  | All types of `VehicleState` fields are valid.     |
 
 ## Tier4 Instance (`TIV`)
 
 | ID       | Name         | Severity | Description                                     |
 | -------- | ------------ | -------- | ----------------------------------------------- |
-| `TIV001` | `load-tier4` | `Error`  | Ensure `Tier4` instance is loaded successfully. |
+| `TIV001` | `load-tier4` | `ERROR`  | Ensure `Tier4` instance is loaded successfully. |

--- a/docs/tutorials/sanity.md
+++ b/docs/tutorials/sanity.md
@@ -1,0 +1,58 @@
+## Sanity Check
+
+### Quick Start
+
+`sanity_check(...)` function performs a series of sanity checks to ensure the integrity of the dataset.
+
+About the defined rules, please refer to [requirement.md](../schema/requirement.md).
+
+```python
+from t4_devkit.common.io import save_json
+from t4_devkit.common.serialize import serialize_dataclass
+from t4_devkit.sanity import sanity_check, print_sanity_result
+
+
+result = sanity_check("<path/to/dataset>")
+
+# display detailed results and summary
+print_sanity_result(result)
+
+# save result to JSON file if you want
+save_json(serialize_dataclass(result), "result.json")
+```
+
+### How to Add New Checkers
+
+All checkers must follow:
+
+- Implement a class that inherits from `Checker` class.
+- Its ID must be unique and belong to one of `RuleGroup` enum.
+- Override the `check() -> list[Reason] | None` method to perform the specific check.
+- Register the checker using `CHECKERS.register()` decorator.
+
+```python
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from t4_devkit.sanity.checker import Checker, RuleID, RuleName, Severity
+from t4_devkit.sanity.registry import CHECKERS
+from t4_devkit.sanity.result import Reason
+
+if TYPE_CHECKING:
+    from t4_devkit.sanity.context import SanityContext
+
+
+@CHECKERS.register()
+class STR000(Checker):
+    """This is a custom checker."""
+
+    id = RuleID("STR000")
+    name = RuleName("my-custom-checker")
+    severity = Severity.ERROR
+    description = "This is a custom checker."
+
+    def check(self, context: SanityContext) -> list[Reason] | None:
+        # Return a list of reasons if the check fails, or None if it passes.
+        return None
+```

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -15,6 +15,7 @@ nav:
       - Initialization: tutorials/initialize.md
       - Visualization: tutorials/render.md
       - Schema Customization: tutorials/customize.md
+      - Sanity Check: tutorials/sanity.md
   - CLI:
       - Home: cli/index.md
       - t4viz: cli/t4viz.md
@@ -22,6 +23,7 @@ nav:
   - API References:
       - t4_devkit.tier4: apis/tier4.md
       - t4_devkit.helper: apis/helper.md
+      - t4_devkit.sanity: apis/sanity.md
       - t4_devkit.schema:
           - Home: apis/schema/index.md
           - Schema Names: apis/schema/name.md


### PR DESCRIPTION
## What

This pull request enhances the documentation for the `sanity` checking functionality, improves clarity in the CLI documentation, and standardizes rule severity levels across the schema requirements. The most significant changes include the addition of a dedicated tutorial for sanity checks, a new API reference section for the `sanity` module, detailed explanations of CLI outputs and exit codes, and normalization of severity naming conventions.

**Documentation Additions and Improvements:**

* Added a new tutorial (`sanity.md`) that explains how to use the `sanity_check` function, display results, save outputs, and implement custom checkers. This makes it easier for users to understand and extend sanity checks.
* Introduced a new API reference section for `t4_devkit.sanity`, including filtering options and improved navigation in the documentation. [[1]](diffhunk://#diff-404852fb8864b91fcd208c7f61832a31d4ab1dbaa59d1567e5a5f8cfebc0a1d6R1-R8) [[2]](diffhunk://#diff-57381c8acc17df6530456c578e76d03d4a1cb287f7edd980502b4a9cedb9524dR18-R26)
* Updated the CLI documentation for `t4sanity` to explain exit status logic, provide a detailed description of the JSON output format, and clarify result table columns. [[1]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50L64-R78) [[2]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50R106-R117)

**Schema Documentation Standardization:**

* Standardized all rule severity labels in `requirement.md` to uppercase (`ERROR`, `WARNING`) for consistency across documentation.

**Navigation and Organization:**

* Updated the documentation navigation (`mkdocs.yaml`) to include the new tutorial and API reference for `sanity`, improving discoverability.
* Removed a duplicate or misplaced reference to `t4_devkit.common.sanity` in the common API documentation for clarity.