### PR TITLE
docs: update document for the sanity

### DIFF
--- a/docs/cli/t4sanity.md
+++ b/docs/cli/t4sanity.md
@@ -65,6 +65,26 @@ $ t4sanity <DATA_ROOT>
 +-----------+---------+--------+--------+---------+----------+
 ```
 
+### Strict Mode
+
+Basically, rules whose **severity is WARNING** will be treated as success.
+
+With `-s; --strict` option enables us to treat warnings as failures:
+
+```shell
+# Run strict mode
+t4sanity <DATA_ROOT> -s
+```
+
+### Exclude Checks
+
+With `-e; --excludes` option enables us to exclude specific checks by specifying the **rule IDs or groups**:
+
+```shell
+# Exclude STR001 and all FMT-relevant rules
+t4sanity <DATA_ROOT> -e STR001 -e FMT
+```
+
 ### Exit Status Logic
 
 `t4sanity` CLI returns the exit code based on the following conditions:
@@ -108,29 +128,9 @@ Here is the description of the JSON format:
 - `dataset_id`: The ID of the dataset.
 - `version`: The version of the dataset.
 - `reports`: An array of rule reports.
-- `id`: The ID of the rule.
-- `name`: The name of the rule.
-- `severity`: How important a rule is.
-- `description`: A description of the rule.
-- `status`: What happened when it ran.
-- `reasons`: An array of reasons for failure or skipped rules, null if passed.
-
-### Exclude Checks
-
-With `-e; --excludes` option enables us to exclude specific checks by specifying the **rule IDs or groups**:
-
-```shell
-# Exclude STR001 and all FMT-relevant rules
-t4sanity <DATA_ROOT> -e STR001 -e FMT
-```
-
-### Strict Mode
-
-Basically, rules whose **severity is WARNING** will be treated as success.
-
-With `-s; --strict` option enables us to treat warnings as failures:
-
-```shell
-# Run strict mode
-t4sanity <DATA_ROOT> -s
-```
+  - `id`: The ID of the rule.
+  - `name`: The name of the rule.
+  - `severity`: How important a rule is.
+  - `description`: A description of the rule.
+  - `status`: What happened when it ran.
+  - `reasons`: An array of reasons for failure or skipped rules, null if passed.


### PR DESCRIPTION
## What

This pull request reorganizes and clarifies the documentation for the `t4sanity` CLI tool by moving the sections on "Strict Mode" and "Exclude Checks" to a more prominent location earlier in the file. The content of these sections remains unchanged, but their placement now improves readability and helps users find important options more easily.

Documentation improvements:

* Moved the "Strict Mode" and "Exclude Checks" sections above the "Exit Status Logic" section to make key CLI options more visible and accessible in `docs/cli/t4sanity.md`. [[1]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50R68-R87) [[2]](diffhunk://#diff-3bfb866e871aa6d8bf153ec55be553fb828f9fac1425df79d86f614cc2473e50L117-L136)