### PR TITLE
test: add unit testings for core functions of sanity module

### DIFF
--- a/tests/sanity/test_sanity_context.py
+++ b/tests/sanity/test_sanity_context.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from returns.maybe import Nothing, Some
+
+from t4_devkit.sanity.context import SanityContext
+from t4_devkit.schema import SchemaName
+
+
+def test_sanity_context() -> None:
+    """Test the sanity context function."""
+    data_root = Path(__file__).parent.parent.joinpath("sample/t4dataset")
+    context = SanityContext.from_path(data_root.as_posix())
+
+    assert context.data_root == Some(data_root)
+    assert context.dataset_id == Some("t4dataset")
+    assert context.version == Nothing
+    assert context.annotation_dir == Some(data_root.joinpath("annotation"))
+    assert context.sensor_data_dir == Some(data_root.joinpath("data"))
+    assert context.map_dir == Some(data_root.joinpath("map"))
+    assert context.bag_dir == Some(data_root.joinpath("input_bag"))
+    assert context.status_json == Some(data_root.joinpath("status.json"))
+
+    for schema in SchemaName:
+        assert context.to_schema_file(schema) == Some(
+            data_root.joinpath("annotation", schema.filename)
+        )

--- a/tests/sanity/test_sanity_registry.py
+++ b/tests/sanity/test_sanity_registry.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from t4_devkit.sanity.checker import RuleID
+from t4_devkit.sanity.registry import RuleGroup
+
+
+def test_rule_group_to_group() -> None:
+    """Test the RuleGroup.to_group method."""
+    # valid rule IDs
+    assert RuleGroup.to_group(RuleID("STR000")) == RuleGroup.STRUCTURE
+    assert RuleGroup.to_group(RuleID("REC000")) == RuleGroup.RECORD
+    assert RuleGroup.to_group(RuleID("REF000")) == RuleGroup.REFERENCE
+    assert RuleGroup.to_group(RuleID("FMT000")) == RuleGroup.FORMAT
+    assert RuleGroup.to_group(RuleID("TIV000")) == RuleGroup.TIER4
+    # invalid rule IDs
+    assert RuleGroup.to_group(RuleID("FOO000")) is None
+    assert RuleGroup.to_group(RuleID("")) is None

--- a/tests/sanity/test_sanity_result.py
+++ b/tests/sanity/test_sanity_result.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from t4_devkit.sanity.checker import RuleID, RuleName, Severity
+from t4_devkit.sanity.result import Reason, Report, SanityResult, Status, make_report, make_skipped
+
+
+@pytest.mark.parametrize(
+    ["severity", "reasons"],
+    [
+        (Severity.ERROR, None),
+        (Severity.WARNING, None),
+        (Severity.ERROR, Reason("Failed reason")),
+        (Severity.WARNING, Reason("Failed reason")),
+    ],
+)
+def test_make_report(severity: Severity, reasons: list[Reason] | None) -> None:
+    """Test the make_report function."""
+    report = make_report(
+        id=RuleID("STR000"),
+        name=RuleName("custom-checker"),
+        severity=severity,
+        description="This is a custom checker.",
+        reasons=reasons,
+    )
+    if reasons:
+        assert report.status == Status.FAILED, f"Expected FAILED status, got {report.status}"
+    else:
+        assert report.status == Status.PASSED, f"Expected PASSED status, got {report.status}"
+
+
+def test_make_skipped() -> None:
+    """Test the make_skipped function."""
+    report = make_skipped(
+        id=RuleID("STR000"),
+        name=RuleName("custom-checker"),
+        severity=Severity.ERROR,
+        description="This is a custom checker.",
+        reason=Reason("Skipped reason"),
+    )
+    assert report.status == Status.SKIPPED, f"Expected SKIPPED status, got {report.status}"
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_sanity_result(strict: bool) -> None:
+    """Test the SanityResult class.
+
+    Note:
+        When strict=True, SanityResult.is_passed(strict) should return True if all reports are passed.
+        Otherwise, it should return True even if at least one report whose severity is WARNING failed.
+    """
+    reports = [
+        Report(
+            id=RuleID("STR000"),
+            name=RuleName("custom-checker0"),
+            severity=Severity.ERROR,
+            description="This is a custom checker0.",
+            status=Status.PASSED,
+            reasons=None,
+        ),
+        Report(
+            id=RuleID("STR001"),
+            name=RuleName("custom-checker1"),
+            severity=Severity.WARNING,
+            description="This is a custom checker1.",
+            status=Status.PASSED,
+            reasons=None,
+        ),
+        Report(
+            id=RuleID("STR002"),
+            name=RuleName("custom-checker2"),
+            severity=Severity.WARNING,
+            description="This is a custom checker2.",
+            status=Status.FAILED,
+            reasons=[Reason("Failed reason2")],
+        ),
+    ]
+    result = SanityResult("test-dataset", "0", reports=reports)
+    if strict:
+        assert result.is_passed(strict=strict) is False
+    else:
+        assert result.is_passed(strict=strict)

--- a/tests/sanity/test_sanity_run.py
+++ b/tests/sanity/test_sanity_run.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from t4_devkit.sanity.run import sanity_check
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_sanity_check(strict: bool) -> None:
+    """Test the sanity check function."""
+    data_root = Path(__file__).parent.parent.joinpath("sample/t4dataset")
+    result = sanity_check(data_root.as_posix())
+
+    if strict:
+        assert result.is_passed(strict=strict) is False
+    else:
+        assert result.is_passed(strict=strict)


### PR DESCRIPTION
## What

This pull request adds a set of new tests for the `sanity` module, improving coverage for key components such as context management, rule group mapping, result evaluation, and the main sanity check function. These tests help ensure that the core logic for dataset structure validation and reporting behaves as expected under different scenarios.

**New test coverage and validation:**

*Sanity context and data discovery:*
- Added `test_sanity_context` to verify that `SanityContext.from_path` correctly identifies data root, dataset ID, and subdirectories, and maps schema files as expected.

*Rule group mapping:*
- Added `test_rule_group_to_group` to ensure that `RuleGroup.to_group` maps rule IDs to their correct groups and handles invalid IDs gracefully.

*Result reporting and evaluation:*
- Added `test_make_report` and `test_make_skipped` to validate the creation of `Report` objects and their status assignment based on reasons and severity.
- Added `test_sanity_result` to check the logic of `SanityResult.is_passed` under both strict and non-strict modes, ensuring correct pass/fail evaluation depending on report severities and statuses.

*Sanity check execution:*
- Added `test_sanity_check` to test the end-to-end execution of the `sanity_check` function, verifying the overall result under different strictness settings.