### PR TITLE
refactor: rename RuleGroup.TIER4 to RuleGroup.TIERIV

### DIFF
--- a/t4_devkit/sanity/registry.py
+++ b/t4_devkit/sanity/registry.py
@@ -13,7 +13,7 @@ class RuleGroup(Enum):
     RECORD = "REC"
     REFERENCE = "REF"
     FORMAT = "FMT"
-    TIER4 = "TIV"
+    TIERIV = "TIV"
 
     @classmethod
     def values(cls) -> list[str]:

--- a/tests/sanity/test_sanity_registry.py
+++ b/tests/sanity/test_sanity_registry.py
@@ -11,7 +11,7 @@ def test_rule_group_to_group() -> None:
     assert RuleGroup.to_group(RuleID("REC000")) == RuleGroup.RECORD
     assert RuleGroup.to_group(RuleID("REF000")) == RuleGroup.REFERENCE
     assert RuleGroup.to_group(RuleID("FMT000")) == RuleGroup.FORMAT
-    assert RuleGroup.to_group(RuleID("TIV000")) == RuleGroup.TIER4
+    assert RuleGroup.to_group(RuleID("TIV000")) == RuleGroup.TIERIV
     # invalid rule IDs
     assert RuleGroup.to_group(RuleID("FOO000")) is None
     assert RuleGroup.to_group(RuleID("")) is None


### PR DESCRIPTION
## What

This pull request updates the naming of one of the enum members in the `RuleGroup` class to improve clarity and consistency. The corresponding test has also been updated to reflect this change.

Enum renaming for clarity:

* Renamed the `TIER4` enum member to `TIERIV` in the `RuleGroup` class in `t4_devkit/sanity/registry.py` to use Roman numerals for consistency.

Test update:

* Updated the test in `tests/sanity/test_sanity_registry.py` to use `TIERIV` instead of `TIER4` when checking the mapping from rule IDs.