### PR TITLE
chore(pointcloud_metainfo): add pointcloud metainfo class

### DIFF
--- a/t4_devkit/dataclass/pointcloud.py
+++ b/t4_devkit/dataclass/pointcloud.py
@@ -233,7 +233,11 @@ class LidarPointCloud(PointCloud):
         scan = np.fromfile(filepath, dtype=np.float32)
         points = scan.reshape((-1, 5))[:, : cls.num_dims()]
 
-        metainfo = PointCloudMetainfo.from_file(metainfo_filepath) if metainfo_filepath is not None else None
+        metainfo = (
+            PointCloudMetainfo.from_file(metainfo_filepath)
+            if metainfo_filepath is not None
+            else None
+        )
 
         return cls(points.T, metainfo=metainfo)
 
@@ -317,7 +321,11 @@ class RadarPointCloud(PointCloud):
         # A NaN in the first point indicates an empty pointcloud.
         point = np.array(points[0])
         if np.any(np.isnan(point)):
-            metainfo = PointCloudMetainfo.from_file(metainfo_filepath) if metainfo_filepath is not None else None
+            metainfo = (
+                PointCloudMetainfo.from_file(metainfo_filepath)
+                if metainfo_filepath is not None
+                else None
+            )
             return cls(np.zeros((feature_count, 0)), metainfo=metainfo)
 
         # Convert to numpy matrix.
@@ -340,7 +348,11 @@ class RadarPointCloud(PointCloud):
         valid = [p in ambig_states for p in points[11, :]]
         points = points[:, valid]
 
-        metainfo = PointCloudMetainfo.from_file(metainfo_filepath) if metainfo_filepath is not None else None
+        metainfo = (
+            PointCloudMetainfo.from_file(metainfo_filepath)
+            if metainfo_filepath is not None
+            else None
+        )
         return cls(points, metainfo=metainfo)
 
 
@@ -366,7 +378,11 @@ class SegmentationPointCloud(PointCloud):
         scan = np.fromfile(point_filepath, dtype=np.float32)
         points = scan.reshape((-1, 5))[:, : cls.num_dims()]
         labels = np.fromfile(label_filepath, dtype=np.uint8)
-        metainfo = PointCloudMetainfo.from_file(metainfo_filepath) if metainfo_filepath is not None else None
+        metainfo = (
+            PointCloudMetainfo.from_file(metainfo_filepath)
+            if metainfo_filepath is not None
+            else None
+        )
         return cls(points.T, labels=labels, metainfo=metainfo)
 
 


### PR DESCRIPTION
This pull requests updates the `PointCloud` dataclass to accept a metainfo field with the following structure (example):
```
{
    "stamp": {
        "sec": 1753168580,
        "nanosec": 47682048
    },
    "sources": [
        {
            "stamp": {
                "sec": 1753168580,
                "nanosec": 48760832
            },
            "idx_begin": 112575,
            "length": 23322,
            "source_id": "REAR_UPPER"
        },
        {
            "stamp": {
                "sec": 1753168580,
                "nanosec": 47682048
            },
            "idx_begin": 100753,
            "length": 11822,
            "source_id": "REAR_LOWER"
        },
```
In addition, it adds validators to check if the sources cover the entire point cloud and provides helper functions to get the list of source ids. 