### PR TITLE
docs: update API references

### DIFF
--- a/docs/apis/schema/other.md
+++ b/docs/apis/schema/other.md
@@ -8,11 +8,12 @@ Following classes are sub items composed of each schema tables.
 
 ::: t4_devkit.schema.tables
     options:
-        members: ["FileFormat", "SensorModality", "VisibilityLevel", "RLEMask", "ShiftState", "IndicatorState", "Indicators", "AdditionalInfo"]
+        members: ["FileFormat", "SensorModality", "VisibilityLevel", "RLEMask", "ShiftState", "IndicatorState", "Indicators", "AdditionalInfo", "AutolabelModel", "AutolabelMixin"]
         show_root_toc_entry: false
         merge_init_into_class: false
         show_signature_annotations: false
         show_docstring_attributes: true
+        show_root_heading: false
 
 ## `Sensor`
 
@@ -25,6 +26,7 @@ Following classes are sub items composed of each schema tables.
         merge_init_into_class: false
         show_signature_annotations: false
         show_docstring_attributes: true
+        show_root_heading: false
 
 ## `ObjectAnn`/`SurfaceAnn`
 
@@ -37,6 +39,7 @@ Following classes are sub items composed of each schema tables.
         merge_init_into_class: false
         show_signature_annotations: false
         show_docstring_attributes: true
+        show_root_heading: false
 
 ## `Visibility`
 
@@ -49,6 +52,7 @@ Following classes are sub items composed of each schema tables.
         merge_init_into_class: false
         show_signature_annotations: false
         show_docstring_attributes: true
+        show_root_heading: false
 
 ## `VehicleState`
 
@@ -61,5 +65,6 @@ Following classes are sub items composed of each schema tables.
         merge_init_into_class: false
         show_signature_annotations: false
         show_docstring_attributes: true
+        show_root_heading: false
 
 <!-- prettier-ignore-end -->

--- a/docs/apis/schema/table.md
+++ b/docs/apis/schema/table.md
@@ -2,7 +2,7 @@
 
 ::: t4_devkit.schema.tables
     options:
-        filters: ["!SchemaBase", "!FileFormat", "!SensorModality", "!VisibilityLevel", "!RLEMask", "!ShiftState", "!IndicatorState", "!Indicators", "!AdditionalInfo"]
+        filters: ["!SchemaBase", "!FileFormat", "!SensorModality", "!VisibilityLevel", "!RLEMask", "!ShiftState", "!IndicatorState", "!Indicators", "!AdditionalInfo", "!AutolabelModel", "!AutolabelMixin"]
         show_root_toc_entry: false
         merge_init_into_class: false
         show_signature_annotations: false

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -64,21 +64,27 @@ plugins:
             - https://numpy.org/doc/stable/objects.inv
             - https://ipython.readthedocs.io/en/stable/objects.inv
           options:
-            docstring_style: google
-            docstring_section_style: list # list spacy table
-            heading_level: 3
+            # general
             filters: ["!^_"]
-            show_bases: true
-            show_source: false
-            inherited_members: false
-            members_order: source # The order of class members
-            parameter_headings: true
-            show_root_heading: false
+            show_bases: false
+            show_source: true
+            # headings
+            heading_level: 2
+            parameter_headings: false
+            show_root_heading: true
             show_symbol_type_heading: true
             show_symbol_type_toc: true
+            # members
+            inherited_members: false
+            members_order: source # The order of class members
+            # docstrings
+            docstring_style: google
+            docstring_section_style: list # list spacy table
             merge_init_into_class: true
+            # signatures
             separate_signature: true
             show_signature_annotations: true
+            show_overload: true
 
 markdown_extensions:
   - pymdownx.highlight:


### PR DESCRIPTION
## What

This pull request updates the API documentation configuration and schema table documentation to improve clarity and maintain consistency. The main changes include adding new schema members, refining table filters, and reorganizing documentation options for better structure and readability.

**Schema documentation updates:**
* Added `AutolabelModel` and `AutolabelMixin` to the `members` list in the `t4_devkit.schema.tables` documentation, ensuring these new schema classes are included in the generated docs.
* Updated the `filters` list in `docs/apis/schema/table.md` to exclude the new `AutolabelModel` and `AutolabelMixin` classes from certain documentation sections, maintaining the intended separation of core and auxiliary schema elements.

**Documentation formatting and structure:**
* Set `show_root_heading: false` for several schema table sub-items in `docs/apis/schema/other.md` to suppress redundant headings and streamline the rendered documentation. [[1]](diffhunk://#diff-96345e3cd9d7b69563d3e17796c05ef2be950c934acc773688f3384b8ab12759R29) [[2]](diffhunk://#diff-96345e3cd9d7b69563d3e17796c05ef2be950c934acc773688f3384b8ab12759R42) [[3]](diffhunk://#diff-96345e3cd9d7b69563d3e17796c05ef2be950c934acc773688f3384b8ab12759R55) [[4]](diffhunk://#diff-96345e3cd9d7b69563d3e17796c05ef2be950c934acc773688f3384b8ab12759R68)
* Refactored the `mkdocs.yaml` configuration for the API reference plugin to clarify and reorganize options, such as adjusting heading levels, toggling root headings, and updating display settings for class members and docstrings, leading to improved documentation structure and readability.