### PR TITLE
fix: resolve invalid import

### DIFF
--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -17,7 +17,7 @@ from t4_devkit.helper import RenderingHelper, TimeseriesHelper
 from t4_devkit.schema import SchemaName, SensorModality, VisibilityLevel, build_schema
 
 if TYPE_CHECKING:
-    from t4_devkit.typing import CamIntrinsicLike, Vector3
+    from t4_devkit.typing import CameraIntrinsicLike, Vector3
 
     from .dataclass import BoxLike
     from .schema import (
@@ -390,7 +390,7 @@ class Tier4:
         as_sensor_coord: bool = True,
         future_seconds: float = 0.0,
         visibility: VisibilityLevel = VisibilityLevel.NONE,
-    ) -> tuple[str, list[BoxLike], CamIntrinsicLike | None]:
+    ) -> tuple[str, list[BoxLike], CameraIntrinsicLike | None]:
         """Return the data path as well as all annotations related to that `sample_data`.
         Note that output boxes is w.r.t base link or sensor coordinate system.
 

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from t4_devkit.dataclass import Box2D, Box3D, Future, PointCloudLike
     from t4_devkit.schema import CalibratedSensor, EgoPose, Sensor
     from t4_devkit.typing import (
-        CamIntrinsicLike,
+        CameraIntrinsicLike,
         NDArrayU8,
         RoiLike,
         RotationLike,
@@ -547,7 +547,7 @@ class RerunViewer:
         modality: str | SensorModality,
         translation: Vector3Like,
         rotation: RotationLike,
-        camera_intrinsic: CamIntrinsicLike | None = None,
+        camera_intrinsic: CameraIntrinsicLike | None = None,
         resolution: Vector2Like | None = None,
     ) -> None:
         """Render a sensor calibration.
@@ -557,7 +557,7 @@ class RerunViewer:
             modality (str | SensorModality): Sensor modality.
             translation (Vector3Like): Sensor translation in ego centric coords.
             rotation (RotationLike): Sensor rotation in ego centric coords.
-            camera_intrinsic (CamIntrinsicLike | None, optional): Camera intrinsic matrix.
+            camera_intrinsic (CameraIntrinsicLike | None, optional): Camera intrinsic matrix.
             resolution (Vector2Like | None, optional): Camera resolution (width, height).
         """
         pass
@@ -591,7 +591,7 @@ class RerunViewer:
         modality: str | SensorModality,
         translation: Vector3Like,
         rotation: RotationLike,
-        camera_intrinsic: CamIntrinsicLike | None = None,
+        camera_intrinsic: CameraIntrinsicLike | None = None,
         resolution: Vector2Like | None = None,
     ) -> None:
         """Render a sensor calibration.
@@ -601,7 +601,7 @@ class RerunViewer:
             modality (str | SensorModality): Sensor modality.
             translation (Vector3Like): Sensor translation in ego centric coords.
             rotation (RotationLike): Sensor rotation in ego centric coords.
-            camera_intrinsic (CamIntrinsicLike | None, optional): Camera intrinsic matrix.
+            camera_intrinsic (CameraIntrinsicLike | None, optional): Camera intrinsic matrix.
             resolution (Vector2Like | None, optional): Camera resolution (width, height).
         """
         rr.log(


### PR DESCRIPTION
## What

This pull request standardizes the naming of the camera intrinsic type throughout the codebase by renaming `CamIntrinsicLike` to `CameraIntrinsicLike` in both type annotations and documentation. This change improves code readability and consistency.

Type annotation and import renaming:

* Updated all references of `CamIntrinsicLike` to `CameraIntrinsicLike` in type annotations and imports in both `t4_devkit/tier4.py` and `t4_devkit/viewer/viewer.py` to maintain consistent naming. [[1]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faL20-R20) [[2]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faL393-R393) [[3]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L30-R30) [[4]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L550-R550) [[5]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L594-R594)

Documentation updates:

* Updated docstrings to use `CameraIntrinsicLike` instead of `CamIntrinsicLike` for parameters describing the camera intrinsic matrix. [[1]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L560-R560) [[2]](diffhunk://#diff-cc7f6bd2c58b549d589883cd9b144ec1aafc01e66ba306440b2a98b421501c88L604-R604)