### PR TITLE
fix: align return to type to its hint

### DIFF
--- a/t4_devkit/common/geometry.py
+++ b/t4_devkit/common/geometry.py
@@ -131,9 +131,9 @@ def is_box_in_image(
     in_front = corners_3d[2, :] > 0.1  # True if a corner is at least 0.1 meter in front of camera.
 
     if visibility == VisibilityLevel.FULL:
-        return np.all(is_visible) and np.all(in_front)
+        return bool(np.all(is_visible) and np.all(in_front))
     elif visibility in (VisibilityLevel.MOST, VisibilityLevel.PARTIAL):
-        return np.any(is_visible)
+        return bool(np.any(is_visible))
     elif visibility == VisibilityLevel.NONE:
         return True
     else:

--- a/t4_devkit/dataclass/box.py
+++ b/t4_devkit/dataclass/box.py
@@ -47,7 +47,7 @@ def distance_box(box: BoxLike, tf_matrix: HomogeneousMatrix) -> float | None:
     else:
         raise TypeError(f"Unexpected box type: {type(box)}")
 
-    return np.linalg.norm(position)
+    return np.linalg.norm(position).item()
 
 
 @define(eq=False)


### PR DESCRIPTION
## What

This pull request makes minor improvements to type consistency and return values in geometry and box utility functions. The changes ensure that functions always return native Python types instead of NumPy types, which can help prevent subtle bugs and improve interoperability.

- Type consistency improvements:
  * Updated the `is_box_in_image` function in `geometry.py` to explicitly cast NumPy boolean results to Python `bool` before returning, ensuring consistent return types.
  * Modified the `distance_box` function in `box.py` to return a native Python `float` using `.item()`, rather than a NumPy scalar, for better type consistency.