### PR TITLE
chore: relax version requirement for rerun-sdk

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "rerun-sdk==0.20.0",
+    "rerun-sdk>=0.20.0",
     "pyquaternion>=0.9.9",
     "matplotlib>=3.9.2",
     "shapely<2.0.0; python_version=='3.10'",


### PR DESCRIPTION
This is to allow for t4-devkit usage in marimo notebooks, which require a newer version of the SDK for things like `rr.show_notebook(width="auto", height="auto")` support.

Tested with `rerun-sdk==0.27` and `t4viz instance ...` and it looked fine.