### PR TITLE
test: update unit testrings for dataclass module

### DIFF
--- a/t4_devkit/dataclass/pointcloud.py
+++ b/t4_devkit/dataclass/pointcloud.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
-from t4_devkit.common.io import load_json
 import struct
 from abc import abstractmethod
 from typing import TYPE_CHECKING, ClassVar, TypeVar
 
 import numpy as np
 from attrs import define, field
+
+from t4_devkit.common.io import load_json
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -252,7 +253,7 @@ class RadarPointCloud(PointCloud):
 
     # class variables
     invalid_states: ClassVar[list[int]] = [0]
-    dynprop_states: ClassVar[list[int]] = range(7)
+    dynprop_states: ClassVar[list[int]] = list(range(7))
     ambig_states: ClassVar[list[int]] = [3]
 
     @staticmethod

--- a/tests/dataclass/test_label.py
+++ b/tests/dataclass/test_label.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from t4_devkit.dataclass.label import SemanticLabel
+
+
+def test_semantic_label() -> None:
+    label = SemanticLabel("car", ["vehicle.car"])
+
+    # check properties
+    assert label.name == "car"
+    assert label.attributes == ["vehicle.car"]
+
+    # same instance
+    assert label == label
+    # same label name
+    assert label == SemanticLabel("car")
+    assert label == "car"
+    # same label name, but different case
+    assert label != SemanticLabel("Car")
+    assert label != "Car"
+    # different label name
+    assert label != SemanticLabel("bike")
+    assert label != "bike"

--- a/tests/dataclass/test_trajectory.py
+++ b/tests/dataclass/test_trajectory.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from pyquaternion import Quaternion
 
 from t4_devkit.dataclass.trajectory import Future
+from t4_devkit.typing import Quaternion
 
 
 def test_future_trajectory(dummy_future: Future) -> None:


### PR DESCRIPTION
## What

This pull request introduces several improvements and fixes across the codebase, including a new test for the `SemanticLabel` class, type consistency updates, and minor code cleanups. The most important changes are summarized below:

**Testing Enhancements:**

* Added a new test file `test_label.py` to verify the behavior and equality logic of the `SemanticLabel` class, including attribute checks and comparison operations.

**Type Consistency and Imports:**

* Updated the import in `test_trajectory.py` to use the internal `Quaternion` type from `t4_devkit.typing` instead of the external `pyquaternion` library, improving consistency and reducing external dependencies.

**Code Quality and Minor Fixes:**

* Moved the import of `load_json` in `pointcloud.py` to follow PEP8 import order, placing third-party and internal imports after standard library imports.
* Changed the definition of the `dynprop_states` class variable in `RadarPointCloud` to explicitly convert the range to a list, ensuring consistent type usage.