### PR TITLE
fix(sanity): pass if the reference token is empty string

### DIFF
--- a/t4_devkit/sanity/reference/base.py
+++ b/t4_devkit/sanity/reference/base.py
@@ -56,6 +56,7 @@ class RecordReferenceChecker(Checker):
             )
             for record in source_records
             if record[self.reference] not in target_tokens
+            and record[self.reference] != ""  # NOTE: success if the reference token is ""
             and self.is_additional_condition_ok(record)
         ] or None
 


### PR DESCRIPTION
## What

This pull request introduces a minor adjustment to the reference check logic in `base.py`. The change ensures that records with an empty string as the reference token are not flagged as missing, improving the accuracy of the sanity check.

- Logic Improvement:
  * Updated the `check` method in `t4_devkit/sanity/reference/base.py` to skip records where the reference token is an empty string, treating them as successful matches.

## Usecase

If the T4 dataset contains only 2D annotations (`object_annotation.json`), both `first_annotation_token` and `last_annotation_token` will be empty string `""`, although instance records are generated.

Therefore, **`fist_annotation_token` and `last_annotation_token` should be the reference to `sample_annotation.json`**.

## How PR Tested?

- [Parent Link (TIER IV INTERNAL)](https://star4.slack.com/archives/C01QZLG6LHF/p1764640174511059)
- [Sample Dataset Link (TIER IV INTERNAL)](https://console.data-search.tier4.jp/projects/x2_dev/t4datasets/471a3751-dac2-451e-9421-552975d50272?version=0&tab=info)

- Before

```shell
  REF010:
     - No reference to 'instance.first_annotation_token':
     - No reference to 'instance.first_annotation_token':
  REF011:
     - No reference to 'instance.last_annotation_token':
     - No reference to 'instance.last_annotation_token':

+--------------------------------------+---------+--------+--------+---------+----------+
|              DatasetID               | Version | Passed | Failed | Skipped | Warnings |
+--------------------------------------+---------+--------+--------+---------+----------+
| 471a3751-dac2-451e-9421-552975d50272 |         |   47   |   2    |    2    |    4     |
+--------------------------------------+---------+--------+--------+---------+----------+
```

- After

```shell
  REF010: ✅
  REF011: ✅

+--------------------------------------+---------+--------+--------+---------+----------+
|              DatasetID               | Version | Passed | Failed | Skipped | Warnings |
+--------------------------------------+---------+--------+--------+---------+----------+
| 471a3751-dac2-451e-9421-552975d50272 |         |   49   |   0    |    2    |    4     |
+--------------------------------------+---------+--------+--------+---------+----------+
```