### PR TITLE
feat(sanity): add checkers to validate next/prev token refers to another one

### DIFF
--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -44,6 +44,12 @@
 | `REF013` | `sample-data-filename-presence`       | `ERROR`  | `SampleData.filename` exists.                                             |
 | `REF014` | `sample-data-info-filename-presence`  | `ERROR`  | `SampleData.info_filename` exists if it is not `None`.                    |
 | `REF015` | `lidarseg-filename-presence`          | `ERROR`  | `LidarSeg.filename` exists if `lidarseg.json` exists.                     |
+| `REF016` | `sample-next-to-another`              | `ERROR`  | `Sample.next` refers to another one unless it is empty.                   |
+| `REF017` | `sample-prev-to-another`              | `ERROR`  | `Sample.prev` refers to another one unless it is empty.                   |
+| `REF018` | `sample-annotation-next-to-another`   | `ERROR`  | `SampleAnnotation.next` refers to another one unless it is empty.         |
+| `REF019` | `sample-annotation-prev-to-another`   | `ERROR`  | `SampleAnnotation.prev` refers to another one unless it is empty.         |
+| `REF020` | `sample-data-next-to-another`         | `ERROR`  | `SampleData.next` refers to another one unless it is empty.               |
+| `REF021` | `sample-data-prev-to-another`         | `ERROR`  | `SampleData.prev` refers to another one unless it is empty.               |
 
 ## Format (`FMT`)
 

--- a/t4_devkit/sanity/reference/__init__.py
+++ b/t4_devkit/sanity/reference/__init__.py
@@ -15,3 +15,9 @@ from .ref012 import *  # noqa
 from .ref013 import *  # noqa
 from .ref014 import *  # noqa
 from .ref015 import *  # noqa
+from .ref016 import *  # noqa
+from .ref017 import *  # noqa
+from .ref018 import *  # noqa
+from .ref019 import *  # noqa
+from .ref020 import *  # noqa
+from .ref021 import *  # noqa

--- a/t4_devkit/sanity/reference/ref016.py
+++ b/t4_devkit/sanity/reference/ref016.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF016(RecordReferenceChecker):
+    """A checker of REF016."""
+
+    id = RuleID("REF016")
+    name = RuleName("sample-next-to-another")
+    severity = Severity.ERROR
+    description = "'Sample.next' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE
+    target = SchemaName.SAMPLE
+    reference = "next"

--- a/t4_devkit/sanity/reference/ref017.py
+++ b/t4_devkit/sanity/reference/ref017.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF017(RecordReferenceChecker):
+    """A checker of REF017."""
+
+    id = RuleID("REF017")
+    name = RuleName("sample-prev-to-another")
+    severity = Severity.ERROR
+    description = "'Sample.prev' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE
+    target = SchemaName.SAMPLE
+    reference = "prev"

--- a/t4_devkit/sanity/reference/ref018.py
+++ b/t4_devkit/sanity/reference/ref018.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF018(RecordReferenceChecker):
+    """A checker of REF018."""
+
+    id = RuleID("REF018")
+    name = RuleName("sample-annotation-next-to-another")
+    severity = Severity.ERROR
+    description = "'SampleAnnotation.next' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE_ANNOTATION
+    target = SchemaName.SAMPLE_ANNOTATION
+    reference = "next"

--- a/t4_devkit/sanity/reference/ref019.py
+++ b/t4_devkit/sanity/reference/ref019.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF019(RecordReferenceChecker):
+    """A checker of REF019."""
+
+    id = RuleID("REF019")
+    name = RuleName("sample-annotation-prev-to-another")
+    severity = Severity.ERROR
+    description = "'SampleAnnotation.prev' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE_ANNOTATION
+    target = SchemaName.SAMPLE_ANNOTATION
+    reference = "prev"

--- a/t4_devkit/sanity/reference/ref020.py
+++ b/t4_devkit/sanity/reference/ref020.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF020(RecordReferenceChecker):
+    """A checker of REF020."""
+
+    id = RuleID("REF020")
+    name = RuleName("sample-data-next-to-another")
+    severity = Severity.ERROR
+    description = "'SampleData.next' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE_DATA
+    target = SchemaName.SAMPLE_DATA
+    reference = "next"

--- a/t4_devkit/sanity/reference/ref021.py
+++ b/t4_devkit/sanity/reference/ref021.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+
+@CHECKERS.register()
+class REF021(RecordReferenceChecker):
+    """A checker of REF021."""
+
+    id = RuleID("REF021")
+    name = RuleName("sample-data-prev-to-another")
+    severity = Severity.ERROR
+    description = "'SampleData.prev' refers to another one unless it is empty."
+    source = SchemaName.SAMPLE_DATA
+    target = SchemaName.SAMPLE_DATA
+    reference = "prev"


### PR DESCRIPTION
## What

This pull request adds six new reference checkers to the sanity validation framework, each enforcing that certain fields referencing other records are either empty or valid references. These new checkers cover `next` and `prev` relationships in `Sample`, `SampleAnnotation`, and `SampleData` schemas. The documentation is updated to reflect these new rules, and the checkers are registered for use in the framework.

### New reference checkers for record relationships

* Added `REF016` to ensure `Sample.next` refers to another record unless it is empty.
* Added `REF017` to ensure `Sample.prev` refers to another record unless it is empty.
* Added `REF018` to ensure `SampleAnnotation.next` refers to another record unless it is empty.
* Added `REF019` to ensure `SampleAnnotation.prev` refers to another record unless it is empty.
* Added `REF020` to ensure `SampleData.next` refers to another record unless it is empty.
* Added `REF021` to ensure `SampleData.prev` refers to another record unless it is empty.

### Documentation and registration

* Updated `docs/schema/requirement.md` to document all six new reference rules.
* Registered all new checkers in the `t4_devkit/sanity/reference/__init__.py` for framework usage.