### PR TITLE
refactor(sanity): add to_str() function to Report

### DIFF
--- a/t4_devkit/sanity/result.py
+++ b/t4_devkit/sanity/result.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from functools import reduce
 from typing import TYPE_CHECKING, NewType
 
 from attrs import define, field
@@ -79,22 +78,22 @@ class Report:
         Returns:
             A string representation of the report.
         """
-        string = ""
+        parts = []
         if not self.is_passed(strict=strict):
-            string += f"\033[31m  {self.id}:\033[0m\n"
+            parts.append(f"\033[31m  {self.id}:\033[0m\n")
             for reason in self.reasons or []:
-                string += f"\033[31m     - {reason}\033[0m\n"
+                parts.append(f"\033[31m     - {reason}\033[0m\n")
         elif self.is_skipped():
-            string += f"\033[36m  {self.id}: [SKIPPED]\033[0m\n"
+            parts.append(f"\033[36m  {self.id}: [SKIPPED]\033[0m\n")
             for reason in self.reasons or []:
-                string += f"\033[36m     - {reason}\033[0m\n"
+                parts.append(f"\033[36m     - {reason}\033[0m\n")
         elif self.severity.is_warning() and self.reasons:
-            string += f"\033[33m  {self.id}:\033[0m\n"
+            parts.append(f"\033[33m  {self.id}:\033[0m\n")
             for reason in self.reasons or []:
-                string += f"\033[33m     - {reason}\033[0m\n"
+                parts.append(f"\033[33m     - {reason}\033[0m\n")
         else:
-            string += f"\033[32m  {self.id}: ✅\033[0m\n"
-        return string
+            parts.append(f"\033[32m  {self.id}: ✅\033[0m\n")
+        return "".join(parts)
 
 
 def make_report(
@@ -169,10 +168,8 @@ class SanityResult:
         Returns:
             A string representation of the result.
         """
-        return reduce(
-            lambda x, y: x + y.to_str(strict=strict),
-            self.reports,
-            f"=== DatasetID: {self.dataset_id} ===\n",
+        return f"=== DatasetID: {self.dataset_id} ===\n" + "".join(
+            report.to_str(strict=strict) for report in self.reports
         )
 
 


### PR DESCRIPTION
## What

This pull request refactors the string representation logic for reporting sanity check results in `t4_devkit/sanity/result.py`. The main change is the extraction of the string formatting logic for individual reports into a new `to_str` method on the report class, enabling cleaner and more maintainable code. The aggregation of report strings in the result class now uses this method, improving readability and reducing code duplication.

Refactoring and code reuse:

* Added a `to_str` method to the report class to encapsulate the logic for generating colored string representations of individual reports, supporting a `strict` flag for warnings.
* Updated the result class's `to_str` method to use the new report-level `to_str` method and `functools.reduce` for aggregating report strings, simplifying and deduplicating the code.

Dependency import:

* Imported `reduce` from `functools` to support the new aggregation approach.