### PR TITLE
chore(deps): restrict rerun-sdk versions to <0.28.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "rerun-sdk>=0.20.0",
+    "rerun-sdk>=0.20.0,<0.28.0",
     "pyquaternion>=0.9.9",
     "matplotlib>=3.9.2",
     "shapely<2.0.0; python_version=='3.10'",


### PR DESCRIPTION
## What

As of `rerun-sdk==0.28.0`, `rerun.set_time_seconds(...)` has been removed.
This pull request updates the dependency constraints for `rerun-sdk` in the `pyproject.toml` file to restrict its version range for improved compatibility.

Dependency updates:

* Restricted the `rerun-sdk` dependency to versions `>=0.20.0,<0.28.0` in `pyproject.toml` to prevent potential incompatibilities with future releases.