### PR TITLE
fix: modify type of size to tuple[int, int]

### DIFF
--- a/t4_devkit/schema/tables/object_ann.py
+++ b/t4_devkit/schema/tables/object_ann.py
@@ -24,11 +24,13 @@ class RLEMask:
     """A dataclass to represent segmentation mask compressed by RLE.
 
     Attributes:
-        size (list[int, int]): Size of image ordering (width, height).
+        size (tuple[int, int]): Size of image ordering (width, height).
         counts (str): RLE compressed mask data.
     """
 
-    size: list[int, int] = field(validator=validators.deep_iterable(validators.instance_of(int)))
+    size: tuple[int, int] = field(
+        converter=tuple, validator=validators.deep_iterable(validators.instance_of(int))
+    )
     counts: str = field(validator=validators.instance_of(str))
 
     @property


### PR DESCRIPTION
## What

This pull request makes a small but important update to the `RLEMask` dataclass in `t4_devkit/schema/tables/object_ann.py`. The change ensures that the `size` attribute is now consistently treated as a tuple instead of a list, improving type consistency and reliability.

- Changed the type of the `size` attribute in `RLEMask` from `list[int, int]` to `tuple[int, int]`, added a converter to enforce the tuple type, and updated the validator accordingly.