### PR TITLE
feat(sanity): check sample data file only if it is valid

### DIFF
--- a/t4_devkit/sanity/reference/ref201.py
+++ b/t4_devkit/sanity/reference/ref201.py
@@ -34,5 +34,5 @@ class REF201(FileReferenceChecker):
         return [
             Reason(f"File not found: {record['filename']}")
             for record in records
-            if not data_root.joinpath(record["filename"]).exists()
+            if record.get("is_valid", True) and not data_root.joinpath(record["filename"]).exists()
         ] or None

--- a/t4_devkit/sanity/reference/ref202.py
+++ b/t4_devkit/sanity/reference/ref202.py
@@ -34,6 +34,7 @@ class REF202(FileReferenceChecker):
         return [
             Reason(f"File not found: {record['info_filename']}")
             for record in records
-            if record.get("info_filename") is not None
+            if record.get("is_valid", True)
+            and record.get("info_filename") is not None
             and not data_root.joinpath(record["info_filename"]).exists()
         ] or None


### PR DESCRIPTION
## What

This pull request updates the file existence checks in two sanity reference modules to ensure that only records marked as valid are considered. This prevents unnecessary file-not-found errors for records that are not valid.

Sanity check improvements:

* Updated `t4_devkit/sanity/reference/ref201.py` so that the file existence check only applies to records where `is_valid` is `True`.
* Updated `t4_devkit/sanity/reference/ref202.py` to include the `is_valid` check before verifying the presence of `info_filename` and its existence.