### PR TITLE
ci: replace ubuntu-latest by ubuntu-slim

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     continue-on-error: true
     strategy:
       matrix:

--- a/.github/workflows/cancel-previous-workflows.yaml
+++ b/.github/workflows/cancel-previous-workflows.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cancel-previous-workflows:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - name: Cancel previous runs

--- a/.github/workflows/deploy-document.yaml
+++ b/.github/workflows/deploy-document.yaml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   deploy-document:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   pre-commit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 5
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:
       - uses: release-drafter/release-drafter@v5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "tabulate>=0.9.0",
     "tqdm>=4.67.1",
     "returns>=0.26.0",
+    "pyarrow<24.0.0", # NOTE: pyarrow==24.0.0 is only supported on macOS
 ]
 
 [dependency-groups]


### PR DESCRIPTION
## What

This pull request updates the GitHub Actions workflow files to use the `ubuntu-slim` runner instead of `ubuntu-latest` for all jobs. This change helps reduce the resource footprint and potentially speeds up CI jobs by using a lighter-weight environment.

**CI/CD Environment Updates:**

* Updated the runner for the `build-and-test` job in `.github/workflows/build-and-test.yaml` from `ubuntu-latest` to `ubuntu-slim`.
* Updated the runner for the `cancel-previous-workflows` job in `.github/workflows/cancel-previous-workflows.yaml` from `ubuntu-latest` to `ubuntu-slim`.
* Updated the runner for the `deploy-document` job in `.github/workflows/deploy-document.yaml` from `ubuntu-latest` to `ubuntu-slim`.
* Updated the runner for the `pre-commit` job in `.github/workflows/pre-commit.yaml` from `ubuntu-latest` to `ubuntu-slim`.
* Updated the runner for the `release-drafter` job in `.github/workflows/release-drafter.yaml` from `ubuntu-latest` to `ubuntu-slim`.