### PR TITLE
refactor: rename Tier4 to T4Devkit

### DIFF
--- a/docs/cli/t4viz.md
+++ b/docs/cli/t4viz.md
@@ -30,7 +30,7 @@ t4viz --install-completion
 
 ### Scene
 
-This command performs the same behavior with [`Tier4.render_scene(...)`](../tutorials/render.md#rendering-scene).
+This command performs the same behavior with [`T4Devkit.render_scene(...)`](../tutorials/render.md#rendering-scene).
 
 For options, run `t4viz scene -h`.
 
@@ -40,7 +40,7 @@ t4viz scene <DATA_ROOT> [OPTIONS]
 
 ### Specific Instance(s)
 
-This command performs the same behavior with [`Tier4.render_instance(...)`](../tutorials/render.md#rendering-instances).
+This command performs the same behavior with [`T4Devkit.render_instance(...)`](../tutorials/render.md#rendering-instances).
 
 For options, run `t4viz instance -h`.
 
@@ -56,7 +56,7 @@ t4viz instance <DATA_ROOT> <INSTANCE_TOKEN1> <INSTANCE_TOKEN2> ... [OPTIONS]
 
 ### PointCloud
 
-This command performs the same behavior with [`Tier4.render_pointcloud(...)`](../tutorials/render.md#rendering-pointcloud).
+This command performs the same behavior with [`T4Devkit.render_pointcloud(...)`](../tutorials/render.md#rendering-pointcloud).
 
 If a pointcloud `sample_data` record has `info_filename`, `t4viz pointcloud` loads the metainfo JSON automatically and uses `num_pts_feats` to parse extended point layouts. Without that file, it falls back to the standard 5-feature layout.
 

--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -93,8 +93,8 @@
 | `FMT017` | `keypoint-field`          | `ERROR`  | `N/A`   | All types of `Keypoint` fields are valid.         |
 | `FMT018` | `vehicle-state-field`     | `ERROR`  | `N/A`   | All types of `VehicleState` fields are valid.     |
 
-## Tier4 Instance (`TIV`)
+## TIER IV Instance (`TIV`)
 
-| ID       | Name         | Severity | Fixable | Description                                     |
-| -------- | ------------ | -------- | ------- | ----------------------------------------------- |
-| `TIV001` | `load-tier4` | `ERROR`  | `N/A`   | Ensure `Tier4` instance is loaded successfully. |
+| ID       | Name         | Severity | Fixable | Description                                        |
+| -------- | ------------ | -------- | ------- | -------------------------------------------------- |
+| `TIV001` | `load-tier4` | `ERROR`  | `N/A`   | Ensure `T4Devkit` instance is loaded successfully. |

--- a/docs/schema/table.md
+++ b/docs/schema/table.md
@@ -333,7 +333,7 @@ visibility {
 
 ## Optional Tables
 
-The following tables are optional, and skipped loading by `Tier4` class if not exists.
+The following tables are optional, and skipped loading by `T4Devkit` class if not exists.
 
 ### LidarSeg
 

--- a/docs/tutorials/customize.md
+++ b/docs/tutorials/customize.md
@@ -77,7 +77,7 @@ class CustomAttribute(SchemaBase):
     description: str | None = field(default=None)
 ```
 
-Note that `CustomAttribute` should be imported before instantiating `Tier4` class.
+Note that `CustomAttribute` should be imported before instantiating `T4Devkit` class.
 Then modify `__init__.py` in order to import it automatically:
 
 ```python title="__init__.py"

--- a/docs/tutorials/initialize.md
+++ b/docs/tutorials/initialize.md
@@ -1,8 +1,8 @@
-## Initialize `Tier4` class
+## Initialize `T4Devkit` class
 
 ---
 
-`Tier4` class expects both following dataset directly structure with or without `<VERSION>` directory:
+`T4Devkit` class expects both following dataset directly structure with or without `<VERSION>` directory:
 
 - With `<VERSION>` directory:
 
@@ -39,13 +39,13 @@
   ...
   ```
 
-You can initialize a `Tier4` instance as follows:
+You can initialize a `T4Devkit` instance as follows:
 
 ```python
 
->>> from t4_devkit import Tier4
+>>> from t4_devkit import T4Devkit
 
->>> t4 = Tier4("data/tier4/", verbose=True)
+>>> t4 = T4Devkit("data/tier4/", verbose=True)
 ======
 Loading T4 tables in `annotation`...
 Reverse indexing...
@@ -75,7 +75,7 @@ Note that if you doesn't specify `revision` parameter in construction, it search
 By specifying `revision=<VERSION>`, you can load the specific version of the dataset.
 
 ```python
->>> t4 = Tier4("data/tier4/", revision="2", verbose=True)
+>>> t4 = T4Devkit("data/tier4/", revision="2", verbose=True)
 ```
 
 ## Access to Schema Fields

--- a/docs/tutorials/render.md
+++ b/docs/tutorials/render.md
@@ -1,6 +1,6 @@
-## Rendering with `Tier4`
+## Rendering with `T4Devkit`
 
-If you want to visualize annotation results, `Tier4` supports some rendering methods as below.
+If you want to visualize annotation results, `T4Devkit` supports some rendering methods as below.
 
 ### Scene
 
@@ -36,7 +36,7 @@ If you want to visualize annotation results, `Tier4` supports some rendering met
 >>> t4.render_pointcloud()
 ```
 
-If `SampleData.info_filename` points to a pointcloud metainfo JSON file, `Tier4.render_pointcloud()` loads it automatically. This allows rendering pointclouds with extended per-point features such as `return_type` or `timestamp`. When no metainfo file is available, the standard 5-feature layout is assumed.
+If `SampleData.info_filename` points to a pointcloud metainfo JSON file, `T4Devkit.render_pointcloud()` loads it automatically. This allows rendering pointclouds with extended per-point features such as `return_type` or `timestamp`. When no metainfo file is available, the standard 5-feature layout is assumed.
 
 ![Render PointCloud GIF](../assets/render_pointcloud.gif)
 

--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 import typer
 
-from t4_devkit import Tier4
+from t4_devkit import T4Devkit
 
 from .version import version_callback
 
@@ -47,7 +47,7 @@ def scene(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, revision=revision, verbose=False)
+    t4 = T4Devkit(data_root, revision=revision, verbose=False)
     t4.render_scene(future_seconds=future, save_dir=output)
 
 
@@ -82,7 +82,7 @@ def instance(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, revision=revision, verbose=False)
+    t4 = T4Devkit(data_root, revision=revision, verbose=False)
     t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output)
 
 
@@ -107,7 +107,7 @@ def pointcloud(
 ) -> None:
     _create_dir(output)
 
-    t4 = Tier4(data_root, revision=revision, verbose=False)
+    t4 = T4Devkit(data_root, revision=revision, verbose=False)
     t4.render_pointcloud(save_dir=output)
 
 

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -23,7 +23,7 @@ from t4_devkit.viewer import (
 )
 
 if TYPE_CHECKING:
-    from t4_devkit import Tier4
+    from t4_devkit import T4Devkit
     from t4_devkit.schema import (
         CalibratedSensor,
         EgoPose,
@@ -49,13 +49,13 @@ class RenderingMode(Enum):
 
 
 class RenderingHelper:
-    """Help `Tier4` class with rendering tasks."""
+    """Help `T4Devkit` class with rendering tasks."""
 
-    def __init__(self, t4: Tier4) -> None:
+    def __init__(self, t4: T4Devkit) -> None:
         """Construct a new object.
 
         Args:
-            t4 (Tier4): `Tier4` instance.
+            t4 (T4Devkit): `T4Devkit` instance.
         """
         self._t4 = t4
         self._label2id: dict[str, int] = {

--- a/t4_devkit/helper/timeseries.py
+++ b/t4_devkit/helper/timeseries.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from t4_devkit.common.timestamp import microseconds2seconds
 
 if TYPE_CHECKING:
-    from t4_devkit import Tier4
+    from t4_devkit import T4Devkit
     from t4_devkit.schema import ObjectAnn, Sample, SampleAnnotation, SampleData
 
 
@@ -13,13 +13,13 @@ __all__ = ["TimeseriesHelper"]
 
 
 class TimeseriesHelper:
-    """Help `Tier4` class with timeseries relevant operations."""
+    """Help `T4Devkit` class with timeseries relevant operations."""
 
-    def __init__(self, t4: Tier4) -> None:
+    def __init__(self, t4: T4Devkit) -> None:
         """Construct a new object.
 
         Args:
-            t4 (Tier4): `Tier4` instance.
+            t4 (T4Devkit): `T4Devkit` instance.
         """
         self._t4 = t4
 

--- a/t4_devkit/sanity/safety.py
+++ b/t4_devkit/sanity/safety.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from returns.result import Result, safe
 
-from t4_devkit import DBMetadata, Tier4, load_metadata
+from t4_devkit import DBMetadata, T4Devkit, load_metadata
 from t4_devkit.common.io import load_json
 
 if TYPE_CHECKING:
@@ -35,9 +35,9 @@ def load_metadata_safe(
 
 
 @safe
-def load_tier4_safe(context: SanityContext) -> Result[Tier4, Exception]:
-    """Load Tier4 instance safely."""
+def load_tier4_safe(context: SanityContext) -> Result[T4Devkit, Exception]:
+    """Load T4Devkit instance safely."""
     data_root = context.data_root.unwrap()
     revision = context.version.value_or(None)
     data_root = data_root.as_posix() if revision is None else data_root.parent.as_posix()
-    return Tier4(data_root, revision=revision, verbose=False)
+    return T4Devkit(data_root, revision=revision, verbose=False)

--- a/t4_devkit/sanity/tier4/tiv001.py
+++ b/t4_devkit/sanity/tier4/tiv001.py
@@ -23,7 +23,7 @@ class TIV001(Checker):
     id = RuleID("TIV001")
     name = RuleName("load-tier4")
     severity = Severity.ERROR
-    description = "Ensure 'Tier4' instance is loaded successfully."
+    description = "Ensure 'T4Devkit' instance is loaded successfully."
 
     def can_skip(self, context: SanityContext) -> Maybe[Reason]:
         match context.data_root:
@@ -37,5 +37,7 @@ class TIV001(Checker):
     def check(self, context: SanityContext) -> list[Reason] | None:
         result = load_tier4_safe(context)
         return (
-            None if is_successful(result) else [Reason(f"Failed to load Tier4: {result.failure()}")]
+            None
+            if is_successful(result)
+            else [Reason(f"Failed to load T4Devkit: {result.failure()}")]
         )

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Sequence
 import numpy as np
 from attrs import define
 from pyquaternion import Quaternion
+from typing_extensions import deprecated
 
 from t4_devkit.common.geometry import is_box_in_image
 from t4_devkit.dataclass import Box2D, Box3D, SemanticLabel, Shape, ShapeType
@@ -43,7 +44,7 @@ if TYPE_CHECKING:
         Visibility,
     )
 
-__all__ = ["DBMetadata", "load_metadata", "load_table", "Tier4"]
+__all__ = ["DBMetadata", "load_metadata", "load_table", "Tier4", "T4Devkit"]
 
 
 @define
@@ -117,7 +118,7 @@ def load_table(annotation_dir: str, schema: SchemaName) -> list[SchemaTable]:
     return build_schema(schema, filepath)
 
 
-class Tier4:
+class T4Devkit:
     """Database class for T4 dataset to help query and retrieve information from the database."""
 
     def __init__(
@@ -799,3 +800,8 @@ class Tier4:
             max_time_seconds=max_time_seconds,
             save_dir=save_dir,
         )
+
+
+@deprecated("Tier4 is deprecated. Use T4Devkit instead.")
+class Tier4(T4Devkit):
+    """This class is deprecated. Use T4Devkit instead."""

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -136,8 +136,8 @@ class T4Devkit:
             verbose (bool, optional): Whether to display status during load.
 
         Examples:
-            >>> from t4_devkit import Tier4
-            >>> t4 = Tier4("data/tier4")
+            >>> from t4_devkit import T4Devkit
+            >>> t4 = T4Devkit("data/tier4")
             ======
             Loading T4 tables in `annotation`...
             Reverse indexing...
@@ -214,7 +214,7 @@ class T4Devkit:
             elapsed_time = time.time() - start_time
             print(f"Done loading in {elapsed_time:.3f} seconds.\n======")
 
-        # initialize helpers after finishing construction of Tier4
+        # initialize helpers after finishing construction of T4Devkit
         self._timeseries_helper = TimeseriesHelper(self)
         self._rendering_helper = RenderingHelper(self)
 

--- a/tests/sanity/test_tier4_checker.py
+++ b/tests/sanity/test_tier4_checker.py
@@ -16,7 +16,7 @@ def _context(path: Path) -> SanityContext:
 
 def test_tiv001_pass() -> None:
     """
-    TIV001 should PASS (Tier4 loads successfully) on the valid sample dataset.
+    TIV001 should PASS (T4Devkit loads successfully) on the valid sample dataset.
     """
     checker = TIV001()
     report = checker(_context(SAMPLE_ROOT))
@@ -38,7 +38,7 @@ def test_tiv001_skip_missing_root(tmp_path: Path) -> None:
 
 def test_tiv001_fail_broken_dataset(tmp_path: Path) -> None:
     """
-    TIV001 should FAIL when Tier4 cannot be initialized due to broken dataset contents.
+    TIV001 should FAIL when T4Devkit cannot be initialized due to broken dataset contents.
 
     We create a dataset root with an 'annotation' directory containing an invalid JSON file
     to trigger a loading failure.
@@ -57,5 +57,5 @@ def test_tiv001_fail_broken_dataset(tmp_path: Path) -> None:
     assert not report.is_skipped(), "Existing root should not trigger skip"
     assert report.reasons, "Failed report must include reasons"
     assert any(
-        "Failed to load Tier4" in r for r in report.reasons
-    ), "Failure reason should indicate Tier4 load issue"
+        "Failed to load T4Devkit" in r for r in report.reasons
+    ), "Failure reason should indicate T4Devkit load issue"

--- a/tests/test_tier4.py
+++ b/tests/test_tier4.py
@@ -9,7 +9,7 @@ import pytest
 
 from t4_devkit.dataclass import Box2D, Box3D, SemanticLabel
 from t4_devkit.schema import SchemaName
-from t4_devkit.tier4 import DBMetadata, Tier4, load_metadata, load_table
+from t4_devkit.tier4 import DBMetadata, T4Devkit, load_metadata, load_table
 from t4_devkit.typing import Quaternion
 
 
@@ -93,11 +93,11 @@ class TestLoadTable:
         assert result == []
 
 
-class TestTier4:
+class TestT4Devkit:
     """Comprehensive integration tests using the sample T4 dataset.
 
     This test class provides comprehensive integration tests that use the real sample T4 dataset
-    located in tests/sample to verify end-to-end functionality of the Tier4 class.
+    located in tests/sample to verify end-to-end functionality of the T4Devkit class.
 
     These tests focus on real data validation instead of mocked objects:
     - Using real data files instead of mocked objects
@@ -108,11 +108,11 @@ class TestTier4:
 
     @pytest.fixture(scope="class")
     def sample_t4(self):
-        """Create a Tier4 instance using the real sample dataset."""
+        """Create a T4Devkit instance using the real sample dataset."""
         sample_dataset_path = Path(__file__).parent / "sample/t4dataset"
         if not sample_dataset_path.exists():
             pytest.skip("Sample dataset not available")
-        return Tier4(sample_dataset_path.as_posix(), verbose=False)
+        return T4Devkit(sample_dataset_path.as_posix(), verbose=False)
 
     def test_dataset_structure_validation(self, sample_t4):
         """Validate the complete structure of the sample dataset."""


### PR DESCRIPTION
## What

This pull request performs a comprehensive renaming of the main database class from `Tier4` to `T4Devkit` throughout the codebase, documentation, and tests. The change standardizes the naming, updates all relevant import statements, docstrings, and user-facing messages, and marks the old `Tier4` class as deprecated in favor of `T4Devkit`. This ensures consistency and clarity for users and developers interacting with the library.

**Core class renaming and deprecation:**
- Renamed the primary database class from `Tier4` to `T4Devkit` in `t4_devkit/tier4.py`, updated all references, and marked `Tier4` as deprecated with a warning to use `T4Devkit` instead. [[1]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faL120-R121) [[2]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faR803-R807)

These changes ensure a smooth transition to the new class name and maintain backward compatibility by deprecating the old class rather than removing it immediately.