### PR TITLE
feat(viewer): add an option whether to render map

### DIFF
--- a/t4_devkit/cli/visualize.py
+++ b/t4_devkit/cli/visualize.py
@@ -44,11 +44,20 @@ def scene(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
+    show_map: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "-m",
+            "--map",
+            help="Whether to render the map.",
+        ),
+    ] = False,
 ) -> None:
     _create_dir(output)
 
     t4 = T4Devkit(data_root, revision=revision, verbose=False)
-    t4.render_scene(future_seconds=future, save_dir=output)
+    t4.render_scene(future_seconds=future, save_dir=output, show_map=show_map)
 
 
 @cli.command("instance", help="Visualize a particular instance in the corresponding scene.")
@@ -79,11 +88,22 @@ def instance(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
+    show_map: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "-m",
+            "--map",
+            help="Whether to render the map.",
+        ),
+    ] = False,
 ) -> None:
     _create_dir(output)
 
     t4 = T4Devkit(data_root, revision=revision, verbose=False)
-    t4.render_instance(instance_token=instance, future_seconds=future, save_dir=output)
+    t4.render_instance(
+        instance_token=instance, future_seconds=future, save_dir=output, show_map=show_map
+    )
 
 
 @cli.command("pointcloud", help="Visualize pointcloud in the corresponding scene.")
@@ -104,11 +124,20 @@ def pointcloud(
             help="Output directory to save recorded .rrd file.",
         ),
     ] = None,
+    show_map: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            "-m",
+            "--map",
+            help="Whether to render the map.",
+        ),
+    ] = False,
 ) -> None:
     _create_dir(output)
 
     t4 = T4Devkit(data_root, revision=revision, verbose=False)
-    t4.render_pointcloud(save_dir=output)
+    t4.render_pointcloud(save_dir=output, show_map=show_map)
 
 
 def _create_dir(dir_path: str | None) -> None:

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -149,6 +149,7 @@ class RenderingHelper:
         max_time_seconds: float = np.inf,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render specified scene.
 
@@ -157,6 +158,7 @@ class RenderingHelper:
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
                 Viewer will be spawned if it is None, otherwise not.
+            show_map (bool, optional): Whether to render the map.
         """
         # search first sample data tokens
         first_lidar_tokens: list[str] = [
@@ -179,7 +181,8 @@ class RenderingHelper:
         contents = self._load_contents(RenderingMode.SCENE)
         viewer = self._init_viewer(app_id, contents=contents, render_ann=True, save_dir=save_dir)
 
-        self._try_render_map(viewer)
+        if show_map:
+            self._try_render_map(viewer)
 
         scene: Scene = self._t4.scene[0]
         first_sample: Sample = self._t4.get("sample", scene.first_sample_token)
@@ -233,6 +236,7 @@ class RenderingHelper:
         *,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render particular instance.
 
@@ -241,7 +245,7 @@ class RenderingHelper:
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
                 Viewer will be spawned if it is None, otherwise not.
-
+            show_map (bool, optional): Whether to render the map.
         """
         instance_tokens = [instance_token] if isinstance(instance_token, str) else instance_token
 
@@ -293,7 +297,8 @@ class RenderingHelper:
         contents = self._load_contents(RenderingMode.INSTANCE)
         viewer = self._init_viewer(app_id, contents=contents, render_ann=True, save_dir=save_dir)
 
-        self._try_render_map(viewer)
+        if show_map:
+            self._try_render_map(viewer)
 
         pointcloud_color_mode = (
             PointCloudColorMode.SEGMENTATION
@@ -344,6 +349,7 @@ class RenderingHelper:
         *,
         max_time_seconds: float = np.inf,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render pointcloud on 3D and 2D view.
 
@@ -351,6 +357,7 @@ class RenderingHelper:
             max_time_seconds (float, optional): Max time length to be rendered [s].
             save_dir (str | None, optional): Directory path to save the recording.
                 Viewer will be spawned if it is None, otherwise not.
+            show_map (bool, optional): Whether to render the map.
 
         TODO:
             Add an option of rendering radar channels.
@@ -379,7 +386,8 @@ class RenderingHelper:
         )
         viewer = self._init_viewer(app_id, contents=contents, render_ann=False, save_dir=save_dir)
 
-        self._try_render_map(viewer)
+        if show_map:
+            self._try_render_map(viewer)
 
         # TODO: support rendering segmentation pointcloud on camera
         futures = self._render_lidar_and_ego(

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -747,6 +747,7 @@ class T4Devkit:
         max_time_seconds: float = np.inf,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render specified scene.
 
@@ -754,11 +755,13 @@ class T4Devkit:
             max_time_seconds (float, optional): Max time length to be rendered [s].
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
+            show_map (bool, optional): Whether to render the map.
         """
         self._rendering_helper.render_scene(
             max_time_seconds=max_time_seconds,
             future_seconds=future_seconds,
             save_dir=save_dir,
+            show_map=show_map,
         )
 
     def render_instance(
@@ -767,6 +770,7 @@ class T4Devkit:
         *,
         future_seconds: float = 0.0,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render particular instance.
 
@@ -774,11 +778,13 @@ class T4Devkit:
             instance_token (str | Sequence[str]): Instance token(s).
             future_seconds (float, optional): Future time in [s].
             save_dir (str | None, optional): Directory path to save the recording.
+            show_map (bool, optional): Whether to render the map.
         """
         self._rendering_helper.render_instance(
             instance_token=instance_token,
             future_seconds=future_seconds,
             save_dir=save_dir,
+            show_map=show_map,
         )
 
     def render_pointcloud(
@@ -786,12 +792,14 @@ class T4Devkit:
         *,
         max_time_seconds: float = np.inf,
         save_dir: str | None = None,
+        show_map: bool = False,
     ) -> None:
         """Render pointcloud on 3D and 2D view.
 
         Args:
             max_time_seconds (float, optional): Max time length to be rendered [s].
             save_dir (str | None, optional): Directory path to save the recording.
+            show_map (bool, optional): Whether to render the map.
 
         TODO:
             Add an option of rendering radar channels.
@@ -799,6 +807,7 @@ class T4Devkit:
         self._rendering_helper.render_pointcloud(
             max_time_seconds=max_time_seconds,
             save_dir=save_dir,
+            show_map=show_map,
         )
 
 


### PR DESCRIPTION
## What

This pull request adds a new feature to the visualization CLI and rendering pipeline that allows users to optionally render the map in scene, instance, and pointcloud visualizations. The change introduces a `--map` (`-m`) command-line flag to the relevant CLI commands and propagates the `show_map` parameter through the codebase to control map rendering.

To improve the rendering speed, `show_map=False` by defaults.

The most important changes are:

**CLI Enhancements:**

* Added a `--map` (`-m`) boolean option to the `scene`, `instance`, and `pointcloud` commands in `t4_devkit/cli/visualize.py` to allow users to specify whether to render the map. [[1]](diffhunk://#diff-f807c1bd47e22712212d8bba8601ee6ee39a71d4c4ed63e98fe6b74dfb75a9c7R47-R60) [[2]](diffhunk://#diff-f807c1bd47e22712212d8bba8601ee6ee39a71d4c4ed63e98fe6b74dfb75a9c7R91-R106) [[3]](diffhunk://#diff-f807c1bd47e22712212d8bba8601ee6ee39a71d4c4ed63e98fe6b74dfb75a9c7R127-R140)

**Rendering Pipeline Updates:**

* Updated the `render_scene`, `render_instance`, and `render_pointcloud` methods in `t4_devkit/helper/rendering.py` and `t4_devkit/tier4.py` to accept and propagate the `show_map` parameter, including updating docstrings to document the new argument. [[1]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R152) [[2]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R161) [[3]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R239) [[4]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2L244-R248) [[5]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R352-R360) [[6]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faR750-R764) [[7]](diffhunk://#diff-9658760189ba6c88343120546d2406d937ee71818871d55b55a4f02f726e98faR773-R810)

**Rendering Logic:**

* Modified the rendering logic in `t4_devkit/helper/rendering.py` to conditionally call the map rendering function (`_try_render_map`) when `show_map` is `True` for all three visualization modes. [[1]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R184) [[2]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R300) [[3]](diffhunk://#diff-e6c3f61227b433334f7ab186aa77d2607eb08b43f3a6a273edba34496044efb2R389)

These changes collectively enable users to control map rendering in visualizations via a simple CLI flag, improving flexibility and usability.