### PR TITLE
chore: bump rerun-sdk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [{ name = "Kotaro Uetake", email = "kotaro.uetake@tier4.jp" }]
 readme = "README.md"
 requires-python = ">=3.10,<3.13"
 dependencies = [
-    "rerun-sdk>=0.20.0,<0.28.0",
+    "rerun-sdk>=0.20.0",
     "pyquaternion>=0.9.9",
     "matplotlib>=3.9.2",
     "shapely<2.0.0; python_version=='3.10'",

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
 
 __all__ = ["RerunViewer"]
 
+RERUN_SDK_VERSION = tuple(int(part) for part in rr.__version__.split(".")[:2])
+
 
 def _check_spatial3d(function: Callable) -> Callable:
     """Check if the viewer has the 3D view space.
@@ -88,6 +90,13 @@ def _check_filepath(function: Callable) -> Callable:
             return function(viewer, filepath)
 
     return checker
+
+
+def _set_time_seconds(timeline: EntityPath, seconds: float) -> None:
+    if RERUN_SDK_VERSION < (0, 27):
+        rr.set_time_seconds(timeline, seconds)
+    else:
+        rr.set_time(timeline, timestamp=seconds)
 
 
 class RerunViewer:
@@ -215,7 +224,7 @@ class RerunViewer:
             self._render_box3ds_with_elements(*args, **kwargs)
 
     def _render_box3ds_with_boxes(self, seconds: float, boxes: Sequence[Box3D]) -> None:
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         batches: dict[str, BatchBox3D] = {}
         for box in boxes:
@@ -288,7 +297,7 @@ class RerunViewer:
                 future=future,
             )
 
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         rr.log(format_entity(EntityPath.MAP, frame_id, EntityPath.BOX), batch.as_boxes3d())
 
@@ -344,7 +353,7 @@ class RerunViewer:
             self._render_box2ds_with_elements(*args, **kwargs)
 
     def _render_box2ds_with_boxes(self, seconds: float, boxes: Sequence[Box2D]) -> None:
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         batches: dict[str, BatchBox2D] = {}
         for box in boxes:
@@ -373,7 +382,7 @@ class RerunViewer:
         for roi, class_id, uuid in zip(rois, class_ids, uuids, strict=True):
             batch.append(roi=roi, class_id=class_id, uuid=uuid)
 
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
         rr.log(format_entity(EntityPath.BASE_LINK, camera, EntityPath.BOX), batch.as_boxes2d())
 
     @_check_spatial2d
@@ -395,7 +404,7 @@ class RerunViewer:
             class_ids (Sequence[int]): Sequence of label ids.
             uuids (Sequence[str | None] | None, optional): Sequence of each instance ID.
         """
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         batch = BatchSegmentation2D()
         if uuids is None:
@@ -425,7 +434,7 @@ class RerunViewer:
             color_mode (PointCloudColorMode, optional): Color mode for pointcloud.
         """
         # TODO(ktro2828): add support of rendering pointcloud on images
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         entity_path = format_entity(EntityPath.BASE_LINK, channel)
         if color_mode == PointCloudColorMode.SEGMENTATION:
@@ -450,7 +459,7 @@ class RerunViewer:
             camera (str): Name of the camera channel.
             image (str | NDArrayU8): Image tensor or path of the image file.
         """
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         entity_path = format_entity(EntityPath.BASE_LINK, camera)
         entity = rr.ImageEncoded(path=image) if isinstance(image, str) else rr.Image(image)
@@ -509,7 +518,7 @@ class RerunViewer:
         rotation: RotationLike,
         geocoordinate: Vector3Like | None = None,
     ) -> None:
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         rr.log(
             EntityPath.BASE_LINK,


### PR DESCRIPTION
## What

This pull request removes the upper limit of `rerun-sdk` version.

Since `rr.set_time_seconds()` has been deprecated in `rerun-sdk=0.27`, this PR includes a wrapper function for backward compatibility.
