### PR TITLE
fix: add backward compatible function for ImageEncoded

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "pytest>=8.2.2",
+    "pytest>=8.2.2,<9",
     "pytest-asyncio>=0.23.7",
     "pytest-mock>=3.14.0",
     "pytest-cov>=6.0.0",

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -99,6 +99,14 @@ def _set_time_seconds(timeline: EntityPath, seconds: float) -> None:
         rr.set_time(timeline, timestamp=seconds)
 
 
+def _encoded_image(path: str):
+    """Create an encoded image archetype across supported Rerun SDK versions."""
+    if RERUN_SDK_VERSION < (0, 28):
+        return rr.ImageEncoded(path=path)
+    else:
+        return rr.EncodedImage(path=path)
+
+
 class RerunViewer:
     """A viewer class that renders some components powered by rerun."""
 
@@ -462,7 +470,7 @@ class RerunViewer:
         _set_time_seconds(EntityPath.TIMELINE, seconds)
 
         entity_path = format_entity(EntityPath.BASE_LINK, camera)
-        entity = rr.ImageEncoded(path=image) if isinstance(image, str) else rr.Image(image)
+        entity = _encoded_image(image) if isinstance(image, str) else rr.Image(image)
 
         rr.log(entity_path, entity)
 

--- a/tests/viewer/test_viewer.py
+++ b/tests/viewer/test_viewer.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 from pyquaternion import Quaternion
 
 from t4_devkit.dataclass import LidarPointCloud
 from t4_devkit.schema import CalibratedSensor, EgoPose, Sensor
 from t4_devkit.viewer import EntityPath, format_entity
+from t4_devkit.viewer import viewer as viewer_module
 
 
 def test_format_entity() -> None:
@@ -89,6 +91,31 @@ def test_render_image(dummy_viewer, dummy_camera_calibration) -> None:
     (width, height), _ = dummy_camera_calibration
     dummy_image = np.zeros((height, width, 3), dtype=np.uint8)
     dummy_viewer.render_image(seconds=seconds, camera="camera", image=dummy_image)
+
+
+@pytest.mark.parametrize(
+    ("rerun_sdk_version", "archetype_name"),
+    [((0, 27), "ImageEncoded"), ((0, 28), "EncodedImage")],
+)
+def test_render_encoded_image(
+    dummy_viewer, monkeypatch, rerun_sdk_version: tuple[int, int], archetype_name: str
+) -> None:
+    """Test rendering encoded images with old and new Rerun archetype names."""
+    paths = []
+
+    class EncodedImage:
+        def __init__(self, *, path: str) -> None:
+            paths.append(path)
+
+    monkeypatch.delattr(viewer_module.rr, "EncodedImage", raising=False)
+    monkeypatch.delattr(viewer_module.rr, "ImageEncoded", raising=False)
+    monkeypatch.setattr(viewer_module.rr, archetype_name, EncodedImage, raising=False)
+    monkeypatch.setattr(viewer_module.rr, "log", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(viewer_module, "RERUN_SDK_VERSION", rerun_sdk_version)
+
+    dummy_viewer.render_image(seconds=1.0, camera="camera", image="image.jpg")
+
+    assert paths == ["image.jpg"]
 
 
 def test_render_ego(dummy_viewer) -> None:


### PR DESCRIPTION
## What

As of `resun-sdk=0.28.0`, `ImageEncoded` was deleted and replaced with `EncodedImage`.
This pull request adds a backward compatible function to load `EncodedImage` or `ImageEncoded` regarding the version of `rerun-sdk`.