### PR TITLE
feat(schema): add new schema for traffic light state

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ More details, please refer to [`t4viz` CLI](./docs/cli/t4viz.md) or [API usage](
 |         | Raw Image                   |   ✅    |
 |         | Raw PointCloud on Image     |   ✅    |
 | Map     | Vector Map                  |   ✅    |
+|         | Traffic Lights              |   ✅    |
 |         | Ego Position on Street View |   ✅    |
 
 ### Sanity Checks

--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -44,6 +44,8 @@
 | `REF010` | `instance-to-first-sample-annotation` | `ERROR`  | `N/A`   | `Instance.first_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record. |
 | `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `N/A`   | `Instance.last_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record.  |
 | `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `N/A`   | `LidarSeg.sample_data_token` refers to `SampleData` record.                           |
+| `REF013` | `traffic-light-to-sample`             | `ERROR`  | `N/A`   | `TrafficLight.sample_token` refers to `Sample` record.                                |
+| `REF014` | `traffic-light-to-lanelet`            | `ERROR`  | `N/A`   | `TrafficLight.lane_connector_id` refers to a lanelet relation in the map.             |
 
 ### Record Reference (A to A')
 
@@ -92,6 +94,7 @@
 | `FMT016` | `surface-ann-field`       | `ERROR`  | `N/A`   | All types of `SurfaceAnn` fields are valid.       |
 | `FMT017` | `keypoint-field`          | `ERROR`  | `N/A`   | All types of `Keypoint` fields are valid.         |
 | `FMT018` | `vehicle-state-field`     | `ERROR`  | `N/A`   | All types of `VehicleState` fields are valid.     |
+| `FMT019` | `traffic-light-field`     | `ERROR`  | `N/A`   | All types of `TrafficLight` fields are valid.     |
 
 ## TIER IV Instance (`TIV`)
 

--- a/docs/schema/table.md
+++ b/docs/schema/table.md
@@ -64,6 +64,17 @@ AdditionalInfo {
 }
 ```
 
+#### `TrafficLightElement`
+
+The `TrafficLightElement` represents a state of a traffic light:
+
+```json
+TrafficLightElement {
+  color: <enum["unknown", "red", "amber", "green", "white"]> -- Traffic light color.
+  shape: <enum["unknown", "circle", "left_arrow", "right_arrow", "up_arrow", "up_left_arrow", "up_right_arrow", "down_arrow", "down_left_arrow", "down_right_arrow", "cross"]> -- Traffic light shape.
+}
+```
+
 ## Mandatory Tables
 
 The following mandatory tables are required for the dataset, so `Tier` class raises runtime error if not found.
@@ -406,5 +417,20 @@ vehicle_state {
   "shift_state":              <option[enum["PARK", "REVERSE", "NEUTRAL", "HIGH", "FORWARD", "LOW", "NONE"]]> -- Shift state of the vehicle.
   "indicators":               <option[Indicators]> -- Indicator state of the vehicle.
   "additional_info":          <option[AdditionalInfo]> -- Additional information about the vehicle state.
+}
+```
+
+### TrafficLight
+
+- Filename: `traffic_light.json`
+
+This table provides information about the traffic light state at a given timestamp, including the color and shape of each light.
+
+```json
+traffic_light {
+  "token":                    <str> -- Unique record identifier.
+  "sample_token":             <str> -- Foreign key to the `Sample` table associated with this annotation.
+  "lane_connector_id":        <str> -- ID of the lane connector in the map.
+  "elements":                 <[TrafficLightElement;N]> -- List of the traffic light elements.
 }
 ```

--- a/docs/schema/table.md
+++ b/docs/schema/table.md
@@ -66,7 +66,7 @@ AdditionalInfo {
 
 #### `TrafficLightElement`
 
-The `TrafficLightElement` represents a state of a traffic light:
+The `TrafficLightElement` represents an individual light element:
 
 ```json
 TrafficLightElement {
@@ -424,7 +424,7 @@ vehicle_state {
 
 - Filename: `traffic_light.json`
 
-This table provides information about the traffic light state at a given timestamp, including the color and shape of each light.
+This table provides information about traffic light elements at a given sample, including the color and shape of each light.
 
 ```json
 traffic_light {

--- a/t4_devkit/helper/rendering.py
+++ b/t4_devkit/helper/rendering.py
@@ -4,6 +4,7 @@ import concurrent
 import concurrent.futures
 import os.path as osp
 import warnings
+from collections import defaultdict
 from concurrent.futures import Future
 from enum import Enum
 from typing import TYPE_CHECKING, Sequence
@@ -35,6 +36,8 @@ if TYPE_CHECKING:
         Scene,
         Sensor,
         SurfaceAnn,
+        TrafficLight,
+        TrafficLightElement,
     )
 
 __all__ = ["RenderingHelper"]
@@ -181,12 +184,16 @@ class RenderingHelper:
         contents = self._load_contents(RenderingMode.SCENE)
         viewer = self._init_viewer(app_id, contents=contents, render_ann=True, save_dir=save_dir)
 
-        if show_map:
-            self._try_render_map(viewer)
-
         scene: Scene = self._t4.scene[0]
         first_sample: Sample = self._t4.get("sample", scene.first_sample_token)
         max_timestamp_us = first_sample.timestamp + seconds2microseconds(max_time_seconds)
+
+        if show_map:
+            self._try_render_map(
+                viewer,
+                first_sample_token=scene.first_sample_token,
+                max_timestamp_us=max_timestamp_us,
+            )
 
         pointcloud_color_mode = (
             PointCloudColorMode.SEGMENTATION
@@ -298,7 +305,11 @@ class RenderingHelper:
         viewer = self._init_viewer(app_id, contents=contents, render_ann=True, save_dir=save_dir)
 
         if show_map:
-            self._try_render_map(viewer)
+            self._try_render_map(
+                viewer,
+                first_sample_token=first_sample.token,
+                max_timestamp_us=max_timestamp_us,
+            )
 
         pointcloud_color_mode = (
             PointCloudColorMode.SEGMENTATION
@@ -387,7 +398,11 @@ class RenderingHelper:
         viewer = self._init_viewer(app_id, contents=contents, render_ann=False, save_dir=save_dir)
 
         if show_map:
-            self._try_render_map(viewer)
+            self._try_render_map(
+                viewer,
+                first_sample_token=first_lidar_sample_data.sample_token,
+                max_timestamp_us=max_timestamp_us,
+            )
 
         # TODO: support rendering segmentation pointcloud on camera
         futures = self._render_lidar_and_ego(
@@ -402,11 +417,53 @@ class RenderingHelper:
 
         _handle_futures(futures)
 
-    def _try_render_map(self, viewer: RerunViewer) -> None:
+    def _try_render_map(
+        self,
+        viewer: RerunViewer,
+        *,
+        first_sample_token: str | None = None,
+        max_timestamp_us: float | None = None,
+    ) -> None:
         lanelet_path = osp.join(self._t4.map_dir, "lanelet2_map.osm")
         if not osp.exists(lanelet_path):
             return
-        viewer.render_map(lanelet_path)
+
+        if not self._t4.traffic_light or first_sample_token is None or max_timestamp_us is None:
+            viewer.render_map(lanelet_path)
+            return
+
+        viewer.render_map(lanelet_path, render_traffic_lights=False)
+        self._render_traffic_light_elements(
+            viewer=viewer,
+            lanelet_path=lanelet_path,
+            first_sample_token=first_sample_token,
+            max_timestamp_us=max_timestamp_us,
+        )
+
+    def _render_traffic_light_elements(
+        self,
+        viewer: RerunViewer,
+        lanelet_path: str,
+        first_sample_token: str,
+        max_timestamp_us: float,
+    ) -> None:
+        traffic_light_elements_by_sample = _traffic_light_elements_by_sample(self._t4.traffic_light)
+        current_sample_token = first_sample_token
+        while current_sample_token != "":
+            sample: Sample = self._t4.get("sample", current_sample_token)
+
+            if max_timestamp_us < sample.timestamp:
+                break
+
+            elements = traffic_light_elements_by_sample.get(sample.token)
+            if elements:
+                viewer.render_traffic_lights(
+                    lanelet_path,
+                    microseconds2seconds(sample.timestamp),
+                    elements,
+                )
+
+            current_sample_token = sample.next
 
     def _render_sensor_calibration(self, viewer: RerunViewer, sample_data_token: str) -> None:
         sample_data: SampleData = self._t4.get("sample_data", sample_data_token)
@@ -671,6 +728,15 @@ def _append_mask(
         camera_masks[camera]["class_ids"] = [class_id]
         camera_masks[camera]["uuids"] = [uuid]
     return camera_masks
+
+
+def _traffic_light_elements_by_sample(
+    traffic_lights: Sequence[TrafficLight],
+) -> dict[str, dict[str, list[TrafficLightElement]]]:
+    output: dict[str, dict[str, list[TrafficLightElement]]] = defaultdict(dict)
+    for traffic_light in traffic_lights:
+        output[traffic_light.sample_token][traffic_light.lane_connector_id] = traffic_light.elements
+    return dict(output)
 
 
 def _handle_futures(futures: list[Future]) -> None:

--- a/t4_devkit/sanity/format/__init__.py
+++ b/t4_devkit/sanity/format/__init__.py
@@ -18,3 +18,4 @@ from .fmt015 import *  # noqa
 from .fmt016 import *  # noqa
 from .fmt017 import *  # noqa
 from .fmt018 import *  # noqa
+from .fmt019 import *  # noqa

--- a/t4_devkit/sanity/format/fmt019.py
+++ b/t4_devkit/sanity/format/fmt019.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import FieldTypeChecker
+
+__all__ = ["FMT019"]
+
+
+@CHECKERS.register()
+class FMT019(FieldTypeChecker):
+    """A checker of FMT019."""
+
+    id = RuleID("FMT019")
+    name = RuleName("traffic-light-field")
+    severity = Severity.ERROR
+    description = "All types of 'TrafficLight' fields are valid."
+    schema = SchemaName.TRAFFIC_LIGHT

--- a/t4_devkit/sanity/reference/__init__.py
+++ b/t4_devkit/sanity/reference/__init__.py
@@ -12,6 +12,8 @@ from .ref009 import *  # noqa
 from .ref010 import *  # noqa
 from .ref011 import *  # noqa
 from .ref012 import *  # noqa
+from .ref013 import *  # noqa
+from .ref014 import *  # noqa
 from .ref101 import *  # noqa
 from .ref102 import *  # noqa
 from .ref103 import *  # noqa

--- a/t4_devkit/sanity/reference/ref013.py
+++ b/t4_devkit/sanity/reference/ref013.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+__all__ = ["REF013"]
+
+
+@CHECKERS.register()
+class REF013(RecordReferenceChecker):
+    """A checker of REF013."""
+
+    id = RuleID("REF013")
+    name = RuleName("traffic-light-to-sample")
+    severity = Severity.ERROR
+    description = "'TrafficLight.sample_token' refers to 'Sample' record."
+    source = SchemaName.TRAFFIC_LIGHT
+    target = SchemaName.SAMPLE
+    reference = "sample_token"

--- a/t4_devkit/sanity/reference/ref014.py
+++ b/t4_devkit/sanity/reference/ref014.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from returns.maybe import Maybe, Nothing, Some
+
+from t4_devkit.lanelet import LaneletParser
+from t4_devkit.schema import SchemaName
+
+from ..checker import Checker, RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from ..result import Reason
+from ..safety import load_json_safe
+
+if TYPE_CHECKING:
+    from ..context import SanityContext
+
+__all__ = ["REF014"]
+
+
+@CHECKERS.register()
+class REF014(Checker):
+    """A checker of REF014."""
+
+    id = RuleID("REF014")
+    name = RuleName("traffic-light-to-lanelet")
+    severity = Severity.ERROR
+    description = "'TrafficLight.lane_connector_id' refers to a lanelet relation in the map."
+
+    def can_skip(self, context: SanityContext) -> Maybe[Reason]:
+        traffic_light_file = context.to_schema_file(SchemaName.TRAFFIC_LIGHT)
+        match traffic_light_file:
+            case Some(traffic_light_path):
+                if not traffic_light_path.exists():
+                    return Maybe.from_value(Reason(f"Missing {SchemaName.TRAFFIC_LIGHT.filename}"))
+                return Nothing
+            case _:
+                return Maybe.from_value(Reason("Missing 'annotation' directory path"))
+
+    def check(self, context: SanityContext) -> list[Reason] | None:
+        traffic_light_file = context.to_schema_file(SchemaName.TRAFFIC_LIGHT).unwrap()
+        match context.map_dir:
+            case Some(map_dir):
+                lanelet_path = map_dir.joinpath("lanelet2_map.osm")
+            case _:
+                return [Reason("Missing 'map' directory path")]
+
+        if not lanelet_path.exists():
+            return [Reason(f"Lanelet2 map file not found: {lanelet_path.as_posix()}")]
+
+        traffic_light_records = load_json_safe(traffic_light_file).unwrap()
+        lanelet_ids = _lanelet_ids(lanelet_path.as_posix())
+
+        return [
+            Reason(
+                "No lanelet relation for "
+                f"'TrafficLight.lane_connector_id': {record['lane_connector_id']}"
+            )
+            for record in traffic_light_records
+            if record["lane_connector_id"] not in lanelet_ids
+        ] or None
+
+
+def _lanelet_ids(lanelet_path: str) -> set[str]:
+    parser = LaneletParser(lanelet_path, verbose=False)
+    return {
+        relation.id
+        for relation in parser.relations.values()
+        if relation.tags.get("type") == "lanelet"
+    }

--- a/t4_devkit/schema/name.py
+++ b/t4_devkit/schema/name.py
@@ -28,6 +28,7 @@ class SchemaName(str, Enum):
         SURFACE_ANN (optional): The annotation of a background object in an image.
         KEYPOINT (optional): The annotation of pose keypoints of an object in an image.
         VEHICLE_STATE (optional): The annotation of ego vehicle states.
+        TRAFFIC_LIGHT (optional): The annotation of traffic light states.
     """
 
     ATTRIBUTE = "attribute"
@@ -48,6 +49,7 @@ class SchemaName(str, Enum):
     SURFACE_ANN = "surface_ann"  # optional
     KEYPOINT = "keypoint"  # optional
     VEHICLE_STATE = "vehicle_state"  # optional
+    TRAFFIC_LIGHT = "traffic_light"  # optional
 
     @property
     def filename(self) -> str:
@@ -70,4 +72,5 @@ class SchemaName(str, Enum):
             SchemaName.SURFACE_ANN,
             SchemaName.KEYPOINT,
             SchemaName.VEHICLE_STATE,
+            SchemaName.TRAFFIC_LIGHT,
         )

--- a/t4_devkit/schema/tables/__init__.py
+++ b/t4_devkit/schema/tables/__init__.py
@@ -19,3 +19,4 @@ from .sensor import *  # noqa
 from .surface_ann import *  # noqa
 from .vehicle_state import *  # noqa
 from .visibility import *  # noqa
+from .traffic_light import *  # noqa

--- a/t4_devkit/schema/tables/traffic_light.py
+++ b/t4_devkit/schema/tables/traffic_light.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from enum import Enum, unique
+
+from attrs import define, field, validators
+
+from ..name import SchemaName
+from .base import SchemaBase, impossible_empty
+from .registry import SCHEMAS
+
+__all__ = [
+    "TrafficLight",
+    "TrafficLightElement",
+    "TrafficLightElementColor",
+    "TrafficLightElementShape",
+]
+
+
+@unique
+class TrafficLightElementColor(str, Enum):
+    UNKNOWN = "unknown"
+    RED = "red"
+    AMBER = "amber"
+    GREEN = "green"
+    WHITE = "white"
+
+
+@unique
+class TrafficLightElementShape(str, Enum):
+    UNKNOWN = "unknown"
+    CIRCLE = "circle"
+    LEFT_ARROW = "left_arrow"
+    RIGHT_ARROW = "right_arrow"
+    UP_ARROW = "up_arrow"
+    UP_LEFT_ARROW = "up_left_arrow"
+    UP_RIGHT_ARROW = "up_right_arrow"
+    DOWN_ARROW = "down_arrow"
+    DOWN_LEFT_ARROW = "down_left_arrow"
+    DOWN_RIGHT_ARROW = "down_right_arrow"
+    CROSS = "cross"
+
+
+@define
+class TrafficLightElement:
+    color: TrafficLightElementColor = field(converter=TrafficLightElementColor)
+    shape: TrafficLightElementShape = field(converter=TrafficLightElementShape)
+
+    @staticmethod
+    def to_traffic_light_element(x: dict | TrafficLightElement) -> TrafficLightElement:
+        if isinstance(x, TrafficLightElement):
+            return x
+        return TrafficLightElement(**x)
+
+
+@define(slots=False)
+@SCHEMAS.register(SchemaName.TRAFFIC_LIGHT)
+class TrafficLight(SchemaBase):
+    """A dataclass to represent schema table of ``traffic_light.json``.
+
+    Attributes:
+        token (str): The token of the traffic light.
+        sample_token (str): Foreign key pointing the sample.
+        lane_connector_id (str): The lane connector ID of the traffic light.
+        elements (list[TrafficLightElement]): List of the traffic light elements.
+    """
+
+    sample_token: str = field(validator=(validators.instance_of(str), impossible_empty()))
+    lane_connector_id: str = field(validator=(validators.instance_of(str), impossible_empty()))
+    elements: list[TrafficLightElement] = field(
+        converter=lambda x: [TrafficLightElement.to_traffic_light_element(s) for s in x],
+        validator=impossible_empty(),
+    )

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         SchemaTable,
         Sensor,
         SurfaceAnn,
+        TrafficLight,
         VehicleState,
         Visibility,
     )
@@ -204,6 +205,9 @@ class T4Devkit:
             self.annotation_dir, SchemaName.VEHICLE_STATE
         )
         self.visibility: list[Visibility] = load_table(self.annotation_dir, SchemaName.VISIBILITY)
+        self.traffic_light: list[TrafficLight] = load_table(
+            self.annotation_dir, SchemaName.TRAFFIC_LIGHT
+        )
 
         # make reverse indexes for common lookups
         self.__make_reverse_index__(verbose)

--- a/t4_devkit/viewer/lanelet.py
+++ b/t4_devkit/viewer/lanelet.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Mapping
 
 import numpy as np
 import rerun as rr
+
+from t4_devkit.schema import TrafficLightElement
 
 from .traffic_light import traffic_light_kind, traffic_light_mesh
 
@@ -75,13 +77,28 @@ def render_lanelets(parser: LaneletParser, root_entity: str) -> None:
             )
 
 
-def render_traffic_elements(parser: LaneletParser, root_entity: str) -> None:
+def render_traffic_elements(
+    parser: LaneletParser,
+    root_entity: str,
+    *,
+    traffic_light_elements: Mapping[str, list[TrafficLightElement]] | None = None,
+    traffic_lights_static: bool = True,
+    render_traffic_lights: bool = True,
+    render_other_elements: bool = True,
+) -> None:
     """Render traffic signs, lights, and other regulatory elements.
 
     Args:
         parser (LaneletParser): The lanelet parser.
         root_entity (str): The root entity to render.
+        traffic_light_elements (Mapping[str, list[TrafficLightElement]] | None, optional):
+            Mapping from lane connector IDs to traffic light elements.
+        traffic_lights_static (bool, optional): Whether to log traffic light meshes as static.
+        render_traffic_lights (bool, optional): Whether to render traffic light meshes.
+        render_other_elements (bool, optional): Whether to render non-traffic-light elements.
     """
+    traffic_light_regulatory_to_lanelet_ids = _traffic_light_regulatory_to_lanelet_ids(parser)
+
     for relation in parser.relations.values():
         if relation.tags.get("type") != "regulatory_element":
             continue
@@ -93,17 +110,18 @@ def render_traffic_elements(parser: LaneletParser, root_entity: str) -> None:
                 if not way:
                     continue
                 coords = parser.way_coordinates(way)
+                is_traffic_light = (
+                    "light" in subtype
+                    and member.role == "refers"
+                    and way.tags.get("type") == "traffic_light"
+                )
                 if "sign" in subtype:
                     color = LANELET_COLORS["traffic_sign"]
                     size = [0.8, 0.8, 0.8]
                     element_type = "sign"
-                elif (
-                    "light" in subtype
-                    and member.role == "refers"
-                    and way.tags.get("type") == "traffic_light"
-                ):
-                    color = LANELET_COLORS["traffic_light"]
-                    size = [0.6, 1.2, 0.6]
+                elif is_traffic_light:
+                    if not render_traffic_lights:
+                        continue
                     element_type = "light"
                 elif "light" in subtype:
                     continue
@@ -121,10 +139,24 @@ def render_traffic_elements(parser: LaneletParser, root_entity: str) -> None:
                     entity_path = (
                         f"{root_entity}/traffic_elements/{kind}_light/{relation.id}_{member.ref}"
                     )
+                    elements = _traffic_light_element(
+                        relation.id,
+                        traffic_light_elements,
+                        traffic_light_regulatory_to_lanelet_ids,
+                    )
                     rr.log(
-                        entity_path, traffic_light_mesh(center, direction, kind=kind), static=True
+                        entity_path,
+                        traffic_light_mesh(
+                            center,
+                            direction,
+                            kind=kind,
+                            elements=elements,
+                        ),
+                        static=traffic_lights_static,
                     )
                 else:
+                    if not render_other_elements:
+                        continue
                     for i, center in enumerate(coords):
                         entity_path = (
                             f"{root_entity}/traffic_elements/{element_type}/{relation.id}_{i}"
@@ -134,6 +166,49 @@ def render_traffic_elements(parser: LaneletParser, root_entity: str) -> None:
                             rr.Boxes3D(sizes=[size], centers=[center], colors=[color]),
                             static=True,
                         )
+
+
+def _traffic_light_regulatory_to_lanelet_ids(parser: LaneletParser) -> dict[str, set[str]]:
+    output: dict[str, set[str]] = {}
+    for relation in parser.relations.values():
+        if relation.tags.get("type") != "lanelet":
+            continue
+
+        for member in relation.members:
+            if member.type != "relation" or member.role != "regulatory_element":
+                continue
+
+            regulatory_relation = parser.relations.get(member.ref)
+            if regulatory_relation is None:
+                continue
+            if (
+                regulatory_relation.tags.get("type") != "regulatory_element"
+                or regulatory_relation.tags.get("subtype") != "traffic_light"
+            ):
+                continue
+
+            output.setdefault(member.ref, set()).add(relation.id)
+
+    return output
+
+
+def _traffic_light_element(
+    regulatory_relation_id: str,
+    traffic_light_elements: Mapping[str, list[TrafficLightElement]] | None,
+    regulatory_to_lanelet_ids: Mapping[str, set[str]],
+) -> list[TrafficLightElement] | None:
+    if traffic_light_elements is None:
+        return None
+
+    if regulatory_relation_id in traffic_light_elements:
+        return traffic_light_elements[regulatory_relation_id]
+
+    lanelet_ids = regulatory_to_lanelet_ids.get(regulatory_relation_id, set())
+    for lanelet_id in sorted(lanelet_ids):
+        if lanelet_id in traffic_light_elements:
+            return traffic_light_elements[lanelet_id]
+
+    return None
 
 
 def render_ways(parser: LaneletParser, root_entity: str) -> None:

--- a/t4_devkit/viewer/traffic_light.py
+++ b/t4_devkit/viewer/traffic_light.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 import numpy as np
 import rerun as rr
 
+from t4_devkit.schema import TrafficLightElementColor, TrafficLightElementShape, TrafficLightElement
+
 __all__ = ["traffic_light_kind", "traffic_light_mesh"]
+
+LENS_COLORS = {
+    TrafficLightElementColor.GREEN: [0.1, 0.9, 0.2],
+    TrafficLightElementColor.AMBER: [1.0, 0.8, 0.1],
+    TrafficLightElementColor.RED: [1.0, 0.1, 0.1],
+}
+INACTIVE_LENS_RGB_SCALE = 0.12
 
 
 def traffic_light_kind(way_subtype: str) -> str:
@@ -17,10 +26,11 @@ def traffic_light_mesh(
     direction: np.ndarray | None = None,
     *,
     kind: str = "vehicle",
+    elements: list[TrafficLightElement] | None = None,
 ) -> rr.Mesh3D:
     if kind == "pedestrian":
-        return _pedestrian_traffic_light_mesh(center, direction)
-    return _vehicle_traffic_light_mesh(center, direction)
+        return _pedestrian_traffic_light_mesh(center, direction, elements)
+    return _vehicle_traffic_light_mesh(center, direction, elements)
 
 
 def _cuboid_mesh(
@@ -115,20 +125,22 @@ def _orient_vertices(
 def _vehicle_traffic_light_mesh(
     center: np.ndarray,
     direction: np.ndarray | None = None,
+    elements: list[TrafficLightElement] | None = None,
 ) -> rr.Mesh3D:
     body_color = [0.05, 0.05, 0.05, 1.0]
     visor_color = [0.02, 0.02, 0.02, 1.0]
-    lens_colors = [
-        [0.1, 0.9, 0.2, 1.0],  # green
-        [1.0, 0.8, 0.1, 1.0],  # yellow
-        [1.0, 0.1, 0.1, 1.0],  # red
+    lens_names = [
+        TrafficLightElementColor.GREEN,
+        TrafficLightElementColor.AMBER,
+        TrafficLightElementColor.RED,
     ]
+    active_color = _circle_element_color(elements)
 
     parts = []
     # add body
     parts.append(_cuboid_mesh(np.array([0.0, 0.0, 1.0]), (1.8, 0.25, 0.6), body_color))
-    # add lens (green, yellow, red)
-    for x_offset, color in zip([-0.55, 0.0, 0.55], lens_colors, strict=True):
+    # add lens (green, amber, red)
+    for x_offset, lens_name in zip([-0.55, 0.0, 0.55], lens_names, strict=True):
         lens_center = np.array([x_offset, -0.13, 1.0])
         parts.append(
             _cuboid_mesh(
@@ -137,7 +149,13 @@ def _vehicle_traffic_light_mesh(
                 visor_color,
             )
         )
-        parts.append(_disc_mesh(lens_center + np.array([0.0, -0.055, 0.0]), 0.18, color))
+        parts.append(
+            _disc_mesh(
+                lens_center + np.array([0.0, -0.055, 0.0]),
+                0.18,
+                _lens_color(lens_name, active_color),
+            )
+        )
 
     return _combine_mesh_parts(parts, center, direction)
 
@@ -145,19 +163,18 @@ def _vehicle_traffic_light_mesh(
 def _pedestrian_traffic_light_mesh(
     center: np.ndarray,
     direction: np.ndarray | None = None,
+    elements: list[TrafficLightElement] | None = None,
 ) -> rr.Mesh3D:
     body_color = [0.05, 0.05, 0.05, 1.0]
     visor_color = [0.02, 0.02, 0.02, 1.0]
-    lens_colors = [
-        [1.0, 0.1, 0.1, 1.0],  # red
-        [0.1, 0.9, 0.2, 1.0],  # green
-    ]
+    lens_names = [TrafficLightElementColor.RED, TrafficLightElementColor.GREEN]
+    active_color = _circle_element_color(elements)
 
     parts = []
     # add body
     parts.append(_cuboid_mesh(np.array([0.0, 0.0, 1.0]), (0.55, 0.22, 1.0), body_color))
     # add lens (red, green)
-    for z_offset, color in zip([1.25, 0.75], lens_colors, strict=True):
+    for z_offset, lens_name in zip([1.25, 0.75], lens_names, strict=True):
         lens_center = np.array([0.0, -0.12, z_offset])
         parts.append(
             _cuboid_mesh(
@@ -166,9 +183,47 @@ def _pedestrian_traffic_light_mesh(
                 visor_color,
             )
         )
-        parts.append(_disc_mesh(lens_center + np.array([0.0, -0.055, 0.0]), 0.14, color))
+        parts.append(
+            _disc_mesh(
+                lens_center + np.array([0.0, -0.055, 0.0]),
+                0.14,
+                _lens_color(lens_name, active_color),
+            )
+        )
 
     return _combine_mesh_parts(parts, center, direction)
+
+
+def _circle_element_color(
+    elements: list[TrafficLightElement] | None,
+) -> TrafficLightElementColor | None:
+    if elements is None:
+        return None
+
+    for element in elements:
+        if element.shape == TrafficLightElementShape.CIRCLE:
+            return element.color
+    return None
+
+
+def _lens_color(
+    lens_name: TrafficLightElementColor,
+    active_color: TrafficLightElementColor | None,
+) -> list[float]:
+    if active_color is None:
+        return _inactive_lens_color(lens_name)
+
+    if active_color == lens_name:
+        return _active_lens_color(lens_name)
+    return _inactive_lens_color(lens_name)
+
+
+def _active_lens_color(lens_name: TrafficLightElementColor) -> list[float]:
+    return LENS_COLORS[lens_name]
+
+
+def _inactive_lens_color(lens_name: TrafficLightElementColor) -> list[float]:
+    return [component * INACTIVE_LENS_RGB_SCALE for component in LENS_COLORS[lens_name]]
 
 
 def _combine_mesh_parts(

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -688,7 +688,7 @@ class RerunViewer:
             traffic_light_elements (Mapping[str, list[TrafficLightElement]]): Mapping from lane
                 connector IDs to traffic light elements.
         """
-        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        _set_time_seconds(EntityPath.TIMELINE, seconds)
         root_entity = format_entity(EntityPath.MAP, EntityPath.VECTOR_MAP)
         render_traffic_elements(
             self._load_lanelet_parser(filepath),

--- a/t4_devkit/viewer/viewer.py
+++ b/t4_devkit/viewer/viewer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os.path as osp
 import warnings
-from typing import TYPE_CHECKING, Callable, Sequence, overload
+from typing import TYPE_CHECKING, Callable, Mapping, Sequence, overload
 
 import numpy as np
 import rerun as rr
@@ -11,7 +11,7 @@ from t4_devkit.common.converter import to_quaternion
 from t4_devkit.common.timestamp import microseconds2seconds
 from t4_devkit.dataclass import SegmentationPointCloud
 from t4_devkit.lanelet import LaneletParser
-from t4_devkit.schema import SensorModality
+from t4_devkit.schema import SensorModality, TrafficLightElement
 
 from .color import PointCloudColorMode, pointcloud_color
 from .config import EntityPath, ViewerConfig, format_entity
@@ -82,12 +82,12 @@ def _check_filepath(function: Callable) -> Callable:
         This function is supposed to be used as a decorator for methods of RerunViewer.
     """
 
-    def checker(viewer: RerunViewer, filepath: str):
+    def checker(viewer: RerunViewer, filepath: str, *args, **kwargs):
         if not osp.exists(filepath):
             warnings.warn(f"File not found: {filepath}")
             return
         else:
-            return function(viewer, filepath)
+            return function(viewer, filepath, *args, **kwargs)
 
     return checker
 
@@ -138,6 +138,7 @@ class RerunViewer:
         self.app_id = app_id
         self.config = config
         self.blueprint = self.config.to_blueprint()
+        self._lanelet_parsers: dict[str, LaneletParser] = {}
 
         rr.init(
             application_id=self.app_id,
@@ -639,20 +640,68 @@ class RerunViewer:
 
     @_check_filepath
     @_check_spatial3d
-    def render_map(self, filepath: str) -> None:
+    def render_map(
+        self,
+        filepath: str,
+        *,
+        traffic_light_elements: Mapping[str, list[TrafficLightElement]] | None = None,
+        traffic_lights_static: bool = True,
+        render_traffic_lights: bool = True,
+    ) -> None:
         """Render vector map.
 
         Args:
             filepath (str): Path to OSM file.
+            traffic_light_elements (Mapping[str, list[TrafficLightElement]] | None, optional):
+                Mapping from lane connector IDs to traffic light elements.
+            traffic_lights_static (bool, optional): Whether to log traffic light meshes as static.
+            render_traffic_lights (bool, optional): Whether to render traffic light meshes.
         """
-        parser = LaneletParser(filepath, verbose=False)
+        parser = self._load_lanelet_parser(filepath)
 
         root_entity = format_entity(EntityPath.MAP, EntityPath.VECTOR_MAP)
         render_lanelets(parser, root_entity)
-        render_traffic_elements(parser, root_entity)
+        render_traffic_elements(
+            parser,
+            root_entity,
+            traffic_light_elements=traffic_light_elements,
+            traffic_lights_static=traffic_lights_static,
+            render_traffic_lights=render_traffic_lights,
+        )
         render_ways(parser, root_entity)
 
         render_geographic_borders(parser, f"{EntityPath.GEOCOORDINATE}/{EntityPath.VECTOR_MAP}")
+
+    @_check_filepath
+    @_check_spatial3d
+    def render_traffic_lights(
+        self,
+        filepath: str,
+        seconds: float,
+        traffic_light_elements: Mapping[str, list[TrafficLightElement]],
+    ) -> None:
+        """Render traffic light meshes with sample-specific elements.
+
+        Args:
+            filepath (str): Path to OSM file.
+            seconds (float): Timestamp in [sec].
+            traffic_light_elements (Mapping[str, list[TrafficLightElement]]): Mapping from lane
+                connector IDs to traffic light elements.
+        """
+        rr.set_time_seconds(EntityPath.TIMELINE, seconds)
+        root_entity = format_entity(EntityPath.MAP, EntityPath.VECTOR_MAP)
+        render_traffic_elements(
+            self._load_lanelet_parser(filepath),
+            root_entity,
+            traffic_light_elements=traffic_light_elements,
+            traffic_lights_static=False,
+            render_other_elements=False,
+        )
+
+    def _load_lanelet_parser(self, filepath: str) -> LaneletParser:
+        if filepath not in self._lanelet_parsers:
+            self._lanelet_parsers[filepath] = LaneletParser(filepath, verbose=False)
+        return self._lanelet_parsers[filepath]
 
 
 def _to_rerun_quaternion(rotation: RotationLike) -> rr.Quaternion:

--- a/tests/sanity/test_format_checkers.py
+++ b/tests/sanity/test_format_checkers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+import shutil
 from pathlib import Path
 
 import pytest
@@ -25,6 +27,7 @@ from t4_devkit.sanity.format.fmt015 import FMT015
 from t4_devkit.sanity.format.fmt016 import FMT016
 from t4_devkit.sanity.format.fmt017 import FMT017  # optional (keypoint) - missing in sample
 from t4_devkit.sanity.format.fmt018 import FMT018
+from t4_devkit.sanity.format.fmt019 import FMT019
 
 # Root of the provided sample dataset (non-versioned)
 SAMPLE_ROOT = Path(__file__).parent.parent.joinpath("sample", "t4dataset")
@@ -55,6 +58,7 @@ ALL_FORMAT_CHECKERS: list[type] = [
     FMT016,
     FMT017,
     FMT018,
+    FMT019,
 ]
 
 
@@ -78,8 +82,35 @@ def test_format_checker_passes(checker_cls: type) -> None:
 
 def test_optional_missing_schemas_present_in_param_list() -> None:
     """Sanity guard: ensure we explicitly covered optional missing schemas."""
-    optional_missing = {"FMT014": FMT014, "FMT017": FMT017}
+    optional_missing = {"FMT014": FMT014, "FMT017": FMT017, "FMT019": FMT019}
     for name, cls in optional_missing.items():
         report = cls()(_context())
         assert report.is_passed(strict=True), f"{name} (missing optional file) should pass"
         assert report.reasons is None
+
+
+def test_fmt019_fail_invalid_traffic_light_element(tmp_path: Path) -> None:
+    """FMT019 fails when traffic_light.json contains invalid element values."""
+    root = tmp_path / "dataset_fmt019_fail"
+
+    shutil.copytree(SAMPLE_ROOT, root)
+    sample_records = json.loads((root / "annotation" / "sample.json").read_text(encoding="utf-8"))
+    (root / "annotation" / "traffic_light.json").write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": sample_records[0]["token"],
+                    "lane_connector_id": "lanelet_id",
+                    "elements": [{"color": "blue", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    report = FMT019()(SanityContext.from_path(root.as_posix()))
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any("blue" in reason for reason in report.reasons)

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -249,9 +249,9 @@ def test_reference_checkers_fail(
 
     checker = checker_cls()
     report = checker(_context(root))
-    assert not report.is_passed(strict=True), (
-        f"{checker_cls.__name__} should fail with invalid reference"
-    )
+    assert not report.is_passed(
+        strict=True
+    ), f"{checker_cls.__name__} should fail with invalid reference"
     assert report.reasons, "Failed report must include reasons"
     # Confirm invalid token mentioned somewhere
     assert any(invalid_token in r for r in report.reasons), "Invalid token should appear in reasons"

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -19,6 +19,8 @@ from t4_devkit.sanity.reference.ref009 import REF009
 from t4_devkit.sanity.reference.ref010 import REF010
 from t4_devkit.sanity.reference.ref011 import REF011
 from t4_devkit.sanity.reference.ref012 import REF012
+from t4_devkit.sanity.reference.ref013 import REF013
+from t4_devkit.sanity.reference.ref014 import REF014
 from t4_devkit.sanity.reference.ref201 import REF201
 from t4_devkit.sanity.reference.ref202 import REF202
 
@@ -86,6 +88,8 @@ def _ensure_is_valid(records: list[dict]) -> list[dict]:
         REF009,
         REF010,
         REF011,
+        REF013,
+        REF014,
         REF201,
         REF202,
     ],
@@ -158,6 +162,49 @@ def test_instance_annotation_reference_uses_existing_target_when_one_target_miss
     assert report.reasons is None
 
 
+def test_ref013_skipped_on_missing_traffic_light() -> None:
+    """REF013 should be skipped because traffic_light.json is optional and absent."""
+    checker = REF013()
+    report = checker(_context(SAMPLE_ROOT))
+    assert report.is_skipped(), "REF013 should be skipped when traffic_light.json is missing"
+
+
+def test_ref014_skipped_on_missing_traffic_light() -> None:
+    """REF014 should be skipped because traffic_light.json is optional and absent."""
+    checker = REF014()
+    report = checker(_context(SAMPLE_ROOT))
+    assert report.is_skipped(), "REF014 should be skipped when traffic_light.json is missing"
+
+
+def test_ref014_pass_valid_lanelet_reference(tmp_path: Path) -> None:
+    """REF014 passes when traffic_light.lane_connector_id exists in lanelet2_map.osm."""
+    root = _copy_dataset(tmp_path / "dataset_ref014_pass")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    sample_records = _load_json(ann_dir / "sample.json")
+    (ann_dir / "traffic_light.json").write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": sample_records[0]["token"],
+                    "lane_connector_id": "1000",
+                    "elements": [{"color": "red", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    checker = REF014()
+    report = checker(_context(root))
+    assert report.is_passed(strict=True)
+    assert report.reasons is None
+
+
 # ---------------------------------------------------------------------------
 # FAIL (invalid references) tests
 # ---------------------------------------------------------------------------
@@ -202,9 +249,9 @@ def test_reference_checkers_fail(
 
     checker = checker_cls()
     report = checker(_context(root))
-    assert not report.is_passed(
-        strict=True
-    ), f"{checker_cls.__name__} should fail with invalid reference"
+    assert not report.is_passed(strict=True), (
+        f"{checker_cls.__name__} should fail with invalid reference"
+    )
     assert report.reasons, "Failed report must include reasons"
     # Confirm invalid token mentioned somewhere
     assert any(invalid_token in r for r in report.reasons), "Invalid token should appear in reasons"
@@ -268,3 +315,126 @@ def test_ref202_fail_missing_info_filename(tmp_path: Path) -> None:
     assert not report.is_passed(strict=True)
     assert report.reasons
     assert any("missing_info.json" in r for r in report.reasons)
+
+
+def test_ref013_fail_invalid_sample_reference(tmp_path: Path) -> None:
+    """REF013 failure by breaking traffic_light.sample_token."""
+    root = _copy_dataset(tmp_path / "dataset_ref013_fail")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    traffic_light_path = ann_dir / "traffic_light.json"
+    traffic_light_path.write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": "nonexistent_sample_token",
+                    "lane_connector_id": "lanelet_id",
+                    "elements": [{"color": "red", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    checker = REF013()
+    report = checker(_context(root))
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any("nonexistent_sample_token" in r for r in report.reasons)
+
+
+def test_ref014_fail_invalid_lanelet_reference(tmp_path: Path) -> None:
+    """REF014 failure by breaking traffic_light.lane_connector_id."""
+    root = _copy_dataset(tmp_path / "dataset_ref014_fail")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    sample_records = _load_json(ann_dir / "sample.json")
+    (ann_dir / "traffic_light.json").write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": sample_records[0]["token"],
+                    "lane_connector_id": "nonexistent_lanelet_id",
+                    "elements": [{"color": "red", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    checker = REF014()
+    report = checker(_context(root))
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any("nonexistent_lanelet_id" in r for r in report.reasons)
+
+
+def test_ref014_fail_missing_lanelet_file_with_traffic_light(tmp_path: Path) -> None:
+    """REF014 fails when traffic_light.json exists but lanelet2_map.osm is missing."""
+    root = _copy_dataset(tmp_path / "dataset_ref014_missing_lanelet")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    sample_records = _load_json(ann_dir / "sample.json")
+    (ann_dir / "traffic_light.json").write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": sample_records[0]["token"],
+                    "lane_connector_id": "1000",
+                    "elements": [{"color": "red", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    lanelet_path = root / "map" / "lanelet2_map.osm"
+    lanelet_path.unlink()
+
+    checker = REF014()
+    report = checker(_context(root))
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any("Lanelet2 map file not found" in r for r in report.reasons)
+
+
+def test_ref014_fail_missing_map_dir_with_traffic_light(tmp_path: Path) -> None:
+    """REF014 fails when traffic_light.json exists but map directory is missing."""
+    root = _copy_dataset(tmp_path / "dataset_ref014_missing_map")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    sample_records = _load_json(ann_dir / "sample.json")
+    (ann_dir / "traffic_light.json").write_text(
+        json.dumps(
+            [
+                {
+                    "token": "traffic_light_token",
+                    "sample_token": sample_records[0]["token"],
+                    "lane_connector_id": "1000",
+                    "elements": [{"color": "red", "shape": "circle"}],
+                }
+            ],
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    shutil.rmtree(root / "map")
+
+    checker = REF014()
+    report = checker(_context(root))
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any("Lanelet2 map file not found" in r for r in report.reasons)

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -403,3 +403,27 @@ def vehicle_state_json(vehicle_state_dict) -> Generator[str, Any, None]:
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
         save_json([vehicle_state_dict], f.name)
         yield f.name
+
+
+# === TrafficLight ===
+@pytest.fixture(scope="session")
+def traffic_light_dict() -> dict:
+    """Return a dummy traffic light as dictionary."""
+    return {
+        "token": "269572c280bd5cf9630ca542e6a60185",
+        "sample_token": "df2bee5733d8607e49bf792fac3014a3",
+        "lane_connector_id": "1234",
+        "elements": [
+            {"color": "red", "shape": "circle"},
+            {"color": "green", "shape": "up_arrow"},
+            {"color": "green", "shape": "left_arrow"},
+        ],
+    }
+
+
+@pytest.fixture(scope="session")
+def traffic_light_json(traffic_light_dict) -> Generator[str, Any, None]:
+    """Return a file path of dummy traffic light record."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        save_json([traffic_light_dict], f.name)
+        yield f.name

--- a/tests/schema/tables/test_traffic_light_table.py
+++ b/tests/schema/tables/test_traffic_light_table.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from t4_devkit.common import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import TrafficLight
+
+
+def test_traffic_light_json(traffic_light_json) -> None:
+    """Test loading traffic light data from a json file."""
+    schemas = TrafficLight.from_json(traffic_light_json)
+    serialized = serialize_dataclasses(schemas)
+    assert isinstance(serialized, list)
+
+
+def test_traffic_light(traffic_light_dict) -> None:
+    """Test loading traffic light data from a dictionary."""
+    schema = TrafficLight.from_dict(traffic_light_dict)
+    serialized = serialize_dataclass(schema)
+    assert serialized == traffic_light_dict
+
+
+def test_new_traffic_light(traffic_light_dict) -> None:
+    """Test generating a traffic light with a new token."""
+    without_token = {k: v for k, v in traffic_light_dict.items() if k != "token"}
+    ret = TrafficLight.new(without_token)
+    # check the new token is not the same with the token in input data
+    assert ret.token != traffic_light_dict["token"]

--- a/tests/schema/test_schema_builder.py
+++ b/tests/schema/test_schema_builder.py
@@ -81,3 +81,8 @@ def test_build_vehicle_state(vehicle_state_json) -> None:
 def test_build_visibility(visibility_json) -> None:
     """Test building visibility."""
     _ = build_schema(SchemaName.VISIBILITY, visibility_json)
+
+
+def test_build_traffic_light(traffic_light_json) -> None:
+    """Test building traffic light."""
+    _ = build_schema(SchemaName.TRAFFIC_LIGHT, traffic_light_json)

--- a/tests/schema/test_schema_name.py
+++ b/tests/schema/test_schema_name.py
@@ -26,6 +26,7 @@ def test_schema_name() -> None:
         "surface_ann": True,
         "keypoint": True,
         "vehicle_state": True,
+        "traffic_light": True,
     }
 
     # check all enum members are covered by above names

--- a/tests/viewer/test_traffic_light.py
+++ b/tests/viewer/test_traffic_light.py
@@ -4,8 +4,13 @@ import numpy as np
 import rerun as rr
 
 from t4_devkit.lanelet import LaneletParser
+from t4_devkit.schema import TrafficLightElementColor, TrafficLightElementShape, TrafficLightElement
 from t4_devkit.viewer.lanelet import render_traffic_elements
-from t4_devkit.viewer.traffic_light import traffic_light_mesh
+from t4_devkit.viewer.traffic_light import (
+    _active_lens_color,
+    _inactive_lens_color,
+    traffic_light_mesh,
+)
 
 
 def test_render_map_traffic_light_as_mesh(tmp_path, monkeypatch) -> None:
@@ -56,6 +61,13 @@ def test_render_map_traffic_light_as_mesh(tmp_path, monkeypatch) -> None:
     <tag k="type" v="regulatory_element"/>
     <tag k="subtype" v="traffic_light"/>
   </relation>
+  <relation id="300">
+    <member type="way" ref="100" role="left"/>
+    <member type="way" ref="101" role="right"/>
+    <member type="relation" ref="200" role="regulatory_element"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+  </relation>
 </osm>
 """,
         encoding="utf-8",
@@ -82,9 +94,15 @@ def test_render_map_traffic_light_as_mesh(tmp_path, monkeypatch) -> None:
     default_vertices = np.array(
         traffic_light_mesh(np.array([0.0, 0.0, 0.0])).vertex_positions.as_arrow_array().to_pylist()
     )
+    default_colors = (
+        traffic_light_mesh(np.array([0.0, 0.0, 0.0])).vertex_colors.as_arrow_array().to_pylist()
+    )
     default_span = default_vertices.max(axis=0) - default_vertices.min(axis=0)
     assert default_span[0] > default_span[2]
     assert len(default_vertices) > 100
+    assert _active_lens_color_value(TrafficLightElementColor.GREEN) not in default_colors
+    assert _active_lens_color_value(TrafficLightElementColor.AMBER) not in default_colors
+    assert _active_lens_color_value(TrafficLightElementColor.RED) not in default_colors
 
     vehicle_vertices = np.array(
         entities["map/vector_map/traffic_elements/vehicle_light/200_100"]
@@ -101,3 +119,207 @@ def test_render_map_traffic_light_as_mesh(tmp_path, monkeypatch) -> None:
     )
     pedestrian_span = pedestrian_vertices.max(axis=0) - pedestrian_vertices.min(axis=0)
     assert pedestrian_span[2] > pedestrian_span[0]
+
+
+def test_render_map_traffic_light_color_from_lane_connector(tmp_path, monkeypatch) -> None:
+    """Test rendering traffic light color from lane connector elements."""
+    lanelet_path = tmp_path / "lanelet2_map.osm"
+    lanelet_path.write_text(
+        """<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6">
+  <node id="1" lat="35.0" lon="139.0" ele="1.0">
+    <tag k="local_x" v="10.0"/>
+    <tag k="local_y" v="20.0"/>
+    <tag k="ele" v="1.0"/>
+  </node>
+  <node id="2" lat="35.0" lon="139.0" ele="1.0">
+    <tag k="local_x" v="10.0"/>
+    <tag k="local_y" v="22.0"/>
+    <tag k="ele" v="1.0"/>
+  </node>
+  <way id="100">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <tag k="type" v="traffic_light"/>
+    <tag k="subtype" v="red_yellow_green"/>
+  </way>
+  <relation id="200">
+    <member type="way" ref="100" role="refers"/>
+    <tag k="type" v="regulatory_element"/>
+    <tag k="subtype" v="traffic_light"/>
+  </relation>
+  <relation id="300">
+    <member type="way" ref="100" role="left"/>
+    <member type="way" ref="100" role="right"/>
+    <member type="relation" ref="200" role="regulatory_element"/>
+    <tag k="type" v="lanelet"/>
+    <tag k="subtype" v="road"/>
+  </relation>
+</osm>
+""",
+        encoding="utf-8",
+    )
+
+    logs = []
+
+    def log(entity_path, entity, *, static=False):
+        logs.append((entity_path, entity, static))
+
+    monkeypatch.setattr("t4_devkit.viewer.lanelet.rr.log", log)
+
+    render_traffic_elements(
+        LaneletParser(str(lanelet_path)),
+        "map/vector_map",
+        traffic_light_elements={
+            "300": [
+                TrafficLightElement(
+                    color=TrafficLightElementColor.RED,
+                    shape=TrafficLightElementShape.CIRCLE,
+                ),
+                TrafficLightElement(
+                    color=TrafficLightElementColor.GREEN,
+                    shape=TrafficLightElementShape.UP_LEFT_ARROW,
+                ),
+            ]
+        },
+        traffic_lights_static=False,
+    )
+
+    assert len(logs) == 1
+    entity_path, entity, static = logs[0]
+    assert entity_path == "map/vector_map/traffic_elements/vehicle_light/200_100"
+    assert isinstance(entity, rr.Mesh3D)
+    assert static is False
+
+    colors = entity.vertex_colors.as_arrow_array().to_pylist()
+    assert _active_lens_color_value(TrafficLightElementColor.RED) in colors
+    assert _active_lens_color_value(TrafficLightElementColor.GREEN) not in colors
+    assert _active_lens_color_value(TrafficLightElementColor.AMBER) not in colors
+
+    vertices = entity.vertex_positions.as_arrow_array().to_pylist()
+    circle_only_vertices = (
+        traffic_light_mesh(
+            np.array([0.0, 0.0, 0.0]),
+            elements=[
+                TrafficLightElement(
+                    color=TrafficLightElementColor.RED,
+                    shape=TrafficLightElementShape.CIRCLE,
+                )
+            ],
+        )
+        .vertex_positions.as_arrow_array()
+        .to_pylist()
+    )
+    assert len(vertices) == len(circle_only_vertices)
+
+
+def test_traffic_light_ignores_non_circle_elements() -> None:
+    """Test non-circle elements do not create additional meshes."""
+    circle_only = traffic_light_mesh(
+        np.array([0.0, 0.0, 0.0]),
+        elements=[
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.CIRCLE,
+            )
+        ],
+    )
+    with_non_circle_elements = traffic_light_mesh(
+        np.array([0.0, 0.0, 0.0]),
+        elements=[
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.CIRCLE,
+            ),
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.LEFT_ARROW,
+            ),
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.UP_RIGHT_ARROW,
+            ),
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.CROSS,
+            ),
+        ],
+    )
+
+    circle_only_vertices = circle_only.vertex_positions.as_arrow_array().to_pylist()
+    non_circle_vertices = with_non_circle_elements.vertex_positions.as_arrow_array().to_pylist()
+    assert len(non_circle_vertices) == len(circle_only_vertices)
+
+
+def test_pedestrian_traffic_light_ignores_non_circle_elements() -> None:
+    """Test pedestrian traffic lights ignore non-circle elements."""
+    circle_only = traffic_light_mesh(
+        np.array([0.0, 0.0, 0.0]),
+        kind="pedestrian",
+        elements=[
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.CIRCLE,
+            ),
+        ],
+    )
+    with_non_circle_element = traffic_light_mesh(
+        np.array([0.0, 0.0, 0.0]),
+        kind="pedestrian",
+        elements=[
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.CIRCLE,
+            ),
+            TrafficLightElement(
+                color=TrafficLightElementColor.GREEN,
+                shape=TrafficLightElementShape.LEFT_ARROW,
+            ),
+        ],
+    )
+
+    circle_only_vertices = circle_only.vertex_positions.as_arrow_array().to_pylist()
+    non_circle_vertices = with_non_circle_element.vertex_positions.as_arrow_array().to_pylist()
+    assert len(non_circle_vertices) == len(circle_only_vertices)
+
+
+def test_inactive_lens_color_is_dimmed() -> None:
+    """Test inactive lens colors are visually dimmed by RGB scaling."""
+    active_color = _active_lens_color(TrafficLightElementColor.GREEN)
+    inactive_color = _inactive_lens_color(TrafficLightElementColor.GREEN)
+
+    assert inactive_color[0] < active_color[0]
+    assert inactive_color[1] < active_color[1]
+    assert inactive_color[2] < active_color[2]
+
+
+def _active_lens_color_value(color: TrafficLightElementColor) -> int:
+    inactive_colors = set(
+        traffic_light_mesh(
+            np.array([0.0, 0.0, 0.0]),
+            elements=[
+                TrafficLightElement(
+                    color=TrafficLightElementColor.UNKNOWN,
+                    shape=TrafficLightElementShape.CIRCLE,
+                )
+            ],
+        )
+        .vertex_colors.as_arrow_array()
+        .to_pylist()
+    )
+    active_colors = set(
+        traffic_light_mesh(
+            np.array([0.0, 0.0, 0.0]),
+            elements=[
+                TrafficLightElement(
+                    color=color,
+                    shape=TrafficLightElementShape.CIRCLE,
+                )
+            ],
+        )
+        .vertex_colors.as_arrow_array()
+        .to_pylist()
+    )
+    lens_colors = active_colors - inactive_colors
+    assert len(lens_colors) == 1
+    return lens_colors.pop()


### PR DESCRIPTION
## What

This pull request introduces a new schema definition called `TrafficLight` which is contained as `annotation/traffic_light.json`.

**Main Changes**
- Add a new schema definition for `TrafficLight`
- Add support of rendering traffic light state with `RerunViewer`
- Add sanity checks for traffic light schema

The following video shows visualization sample of traffic light states:

```shell
# -m: option to render map information

$t4viz scene <DATASET_PATH> -m
```

[Screencast from 07-29-2026 12:47:09 AM.webm](https://github.com/user-attachments/assets/b44d5a63-4527-4bc0-824a-f3a36c49893d)
