### PR TITLE
feat(schema): add new traffic light schema for object detection

### DIFF
--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -44,6 +44,8 @@
 | `REF010` | `instance-to-first-sample-annotation` | `ERROR`  | `N/A`   | `Instance.first_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record. |
 | `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `N/A`   | `Instance.last_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record.  |
 | `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `N/A`   | `LidarSeg.sample_data_token` refers to `SampleData` record.                           |
+| `REF013` | `traffic-light-to-instance`           | `ERROR`  | `N/A`   | `TrafficLight.instance_token` refers to `Instance` record.                            |
+| `REF014` | `traffic-light-to-lanelet`            | `ERROR`  | `N/A`   | `TrafficLight.traffic_light_linestring_id` refers to a lanelet relation in the map.   |
 
 ### Record Reference (A to A')
 
@@ -92,6 +94,7 @@
 | `FMT016` | `surface-ann-field`       | `ERROR`  | `N/A`   | All types of `SurfaceAnn` fields are valid.       |
 | `FMT017` | `keypoint-field`          | `ERROR`  | `N/A`   | All types of `Keypoint` fields are valid.         |
 | `FMT018` | `vehicle-state-field`     | `ERROR`  | `N/A`   | All types of `VehicleState` fields are valid.     |
+| `FMT019` | `traffic-light-field`     | `ERROR`  | `N/A`   | All types of `TrafficLight` fields are valid.     |
 
 ## TIER IV Instance (`TIV`)
 

--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -45,7 +45,7 @@
 | `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `N/A`   | `Instance.last_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record.  |
 | `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `N/A`   | `LidarSeg.sample_data_token` refers to `SampleData` record.                           |
 | `REF013` | `traffic-light-to-instance`           | `ERROR`  | `N/A`   | `TrafficLight.instance_token` refers to `Instance` record.                            |
-| `REF014` | `traffic-light-to-lanelet`            | `ERROR`  | `N/A`   | `TrafficLight.traffic_light_linestring_id` refers to a lanelet relation in the map.   |
+| `REF014` | `traffic-light-to-lanelet`            | `ERROR`  | `N/A`   | `TrafficLight.primitive_id` refers to a corresponding ID in a lanelet.                |
 
 ### Record Reference (A to A')
 

--- a/docs/schema/table.md
+++ b/docs/schema/table.md
@@ -408,3 +408,17 @@ vehicle_state {
   "additional_info":          <option[AdditionalInfo]> -- Additional information about the vehicle state.
 }
 ```
+
+### TrafficLight
+
+- Filename: `traffic_light.json`
+
+This table provides information about the traffic light at a given timestamp, including the state of the traffic light and the associated lanelet linestring ID.
+
+```json
+traffic_light {
+  "token":                      <str> -- Unique record identifier.
+  "instance_token":             <str> -- Foreign key to the `Instance` table associated with the instance of the object.
+  "traffic_light_linestring_id": <str> -- ID of the lanelet linestring associated with the traffic light.
+}
+```

--- a/docs/schema/table.md
+++ b/docs/schema/table.md
@@ -413,12 +413,21 @@ vehicle_state {
 
 - Filename: `traffic_light.json`
 
-This table provides information about the traffic light at a given timestamp, including the state of the traffic light and the associated lanelet linestring ID.
+This table provides relationships between traffic light annotations and lanelet primitives.
 
 ```json
 traffic_light {
-  "token":                      <str> -- Unique record identifier.
-  "instance_token":             <str> -- Foreign key to the `Instance` table associated with the instance of the object.
-  "traffic_light_linestring_id": <str> -- ID of the lanelet linestring associated with the traffic light.
+  "token":                    <str> -- Unique record identifier.
+  "instance_token":           <str> -- Foreign key to the `Instance` table associated with the instance of the object.
+  "primitive_id":             <str> -- ID of the lanelet primitive representing the physical lamp unit.
 }
 ```
+
+The following table explains the overview of traffic light related ID types on Lanelet2:
+
+| ID Type               | OSM Element                           | Description                                              |
+| --------------------- | ------------------------------------- | -------------------------------------------------------- |
+| Primitive ID          | `way` (`type: traffic_light`)         | ID of the linestring representing the physical lamp unit |
+| Light Bulbs ID        | `way` (`type: light_bulbs`)           | ID of the linestring grouping individual bulb nodes      |
+| Regulatory Element ID | `relation` (`subtype: traffic_light`) | ID of the relation that binds a traffic control unit     |
+| Stop Line ID          | `way` (`type: stop_line`)             | ID of the linestring representing the stop line          |

--- a/t4_devkit/sanity/format/__init__.py
+++ b/t4_devkit/sanity/format/__init__.py
@@ -18,3 +18,4 @@ from .fmt015 import *  # noqa
 from .fmt016 import *  # noqa
 from .fmt017 import *  # noqa
 from .fmt018 import *  # noqa
+from .fmt019 import *  # noqa

--- a/t4_devkit/sanity/format/fmt019.py
+++ b/t4_devkit/sanity/format/fmt019.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import FieldTypeChecker
+
+__all__ = ["FMT019"]
+
+
+@CHECKERS.register()
+class FMT019(FieldTypeChecker):
+    """A checker of FMT019."""
+
+    id = RuleID("FMT019")
+    name = RuleName("traffic-light-field")
+    severity = Severity.ERROR
+    description = "All types of 'TrafficLight' fields are valid."
+    schema = SchemaName.TRAFFIC_LIGHT

--- a/t4_devkit/sanity/reference/__init__.py
+++ b/t4_devkit/sanity/reference/__init__.py
@@ -12,6 +12,8 @@ from .ref009 import *  # noqa
 from .ref010 import *  # noqa
 from .ref011 import *  # noqa
 from .ref012 import *  # noqa
+from .ref013 import *  # noqa
+from .ref014 import *  # noqa
 from .ref101 import *  # noqa
 from .ref102 import *  # noqa
 from .ref103 import *  # noqa

--- a/t4_devkit/sanity/reference/ref013.py
+++ b/t4_devkit/sanity/reference/ref013.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from t4_devkit.schema import SchemaName
+
+from ..checker import RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from .base import RecordReferenceChecker
+
+__all__ = ["REF013"]
+
+
+@CHECKERS.register()
+class REF013(RecordReferenceChecker):
+    """A checker of REF013."""
+
+    id = RuleID("REF013")
+    name = RuleName("traffic-light-to-instance")
+    severity = Severity.ERROR
+    description = "'TrafficLight.instance_token' refers to 'Instance' record."
+    source = SchemaName.TRAFFIC_LIGHT
+    target = SchemaName.INSTANCE
+    reference = "instance_token"

--- a/t4_devkit/sanity/reference/ref014.py
+++ b/t4_devkit/sanity/reference/ref014.py
@@ -61,4 +61,6 @@ class REF014(Checker):
 def _traffic_light_ids(lanelet_path: str) -> set[str]:
     """Returns the set of traffic light primitive IDs from the lanelet map."""
     parser = LaneletParser(lanelet_path, verbose=False)
-    return {way.id for way in parser.ways.values() if way.tags.get("type") == "traffic_light"}
+
+    # Some Lanelet parsers expose way IDs as integers, while primitive_id is stored as a string.
+    return {str(way.id) for way in parser.ways.values() if way.tags.get("type") == "traffic_light"}

--- a/t4_devkit/sanity/reference/ref014.py
+++ b/t4_devkit/sanity/reference/ref014.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from returns.maybe import Maybe, Nothing, Some
+
+from t4_devkit.lanelet import LaneletParser
+from t4_devkit.schema import SchemaName
+
+from ..checker import Checker, RuleID, RuleName, Severity
+from ..registry import CHECKERS
+from ..result import Reason
+from ..safety import load_json_safe
+
+if TYPE_CHECKING:
+    from ..context import SanityContext
+
+__all__ = ["REF014"]
+
+
+@CHECKERS.register()
+class REF014(Checker):
+    """A checker of REF014."""
+
+    id = RuleID("REF014")
+    name = RuleName("traffic-light-to-lanelet")
+    severity = Severity.ERROR
+    description = (
+        "'TrafficLight.traffic_light_linestring_id' refers to a lanelet relation in the map."
+    )
+
+    def can_skip(self, context: SanityContext) -> Maybe[Reason]:
+        traffic_light_file = context.to_schema_file(SchemaName.TRAFFIC_LIGHT)
+        match traffic_light_file:
+            case Some(traffic_light_path):
+                if not traffic_light_path.exists():
+                    return Maybe.from_value(Reason(f"Missing {SchemaName.TRAFFIC_LIGHT.filename}"))
+                return Nothing
+            case _:
+                return Maybe.from_value(Reason("Missing 'annotation' directory path"))
+
+    def check(self, context: SanityContext) -> list[Reason] | None:
+        traffic_light_file = context.to_schema_file(SchemaName.TRAFFIC_LIGHT).unwrap()
+        match context.map_dir:
+            case Some(map_dir):
+                lanelet_path = map_dir.joinpath("lanelet2_map.osm")
+            case _:
+                return [Reason("Missing 'map' directory path")]
+
+        if not lanelet_path.exists():
+            return [Reason(f"Lanelet2 map file not found: {lanelet_path.as_posix()}")]
+
+        traffic_light_records = load_json_safe(traffic_light_file).unwrap()
+        traffic_light_ids = _traffic_light_ids(lanelet_path.as_posix())
+
+        return [
+            Reason(
+                "No lanelet relation for "
+                f"'TrafficLight.traffic_light_linestring_id': {record['traffic_light_linestring_id']}"
+            )
+            for record in traffic_light_records
+            if record["traffic_light_linestring_id"] not in traffic_light_ids
+        ] or None
+
+
+def _traffic_light_ids(lanelet_path: str) -> set[str]:
+    parser = LaneletParser(lanelet_path, verbose=False)
+    return {way.id for way in parser.ways.values() if way.tags.get("type") == "traffic_light"}

--- a/t4_devkit/sanity/reference/ref014.py
+++ b/t4_devkit/sanity/reference/ref014.py
@@ -25,9 +25,7 @@ class REF014(Checker):
     id = RuleID("REF014")
     name = RuleName("traffic-light-to-lanelet")
     severity = Severity.ERROR
-    description = (
-        "'TrafficLight.traffic_light_linestring_id' refers to a lanelet relation in the map."
-    )
+    description = "'TrafficLight.primitive_id' refers to a corresponding ID in a lanelet."
 
     def can_skip(self, context: SanityContext) -> Maybe[Reason]:
         traffic_light_file = context.to_schema_file(SchemaName.TRAFFIC_LIGHT)
@@ -54,15 +52,13 @@ class REF014(Checker):
         traffic_light_ids = _traffic_light_ids(lanelet_path.as_posix())
 
         return [
-            Reason(
-                "No lanelet relation for "
-                f"'TrafficLight.traffic_light_linestring_id': {record['traffic_light_linestring_id']}"
-            )
+            Reason(f"No lanelet relation for 'TrafficLight.primitive_id': {record['primitive_id']}")
             for record in traffic_light_records
-            if record["traffic_light_linestring_id"] not in traffic_light_ids
+            if record["primitive_id"] not in traffic_light_ids
         ] or None
 
 
 def _traffic_light_ids(lanelet_path: str) -> set[str]:
+    """Returns the set of traffic light primitive IDs from the lanelet map."""
     parser = LaneletParser(lanelet_path, verbose=False)
     return {way.id for way in parser.ways.values() if way.tags.get("type") == "traffic_light"}

--- a/t4_devkit/schema/name.py
+++ b/t4_devkit/schema/name.py
@@ -28,6 +28,7 @@ class SchemaName(str, Enum):
         SURFACE_ANN (optional): The annotation of a background object in an image.
         KEYPOINT (optional): The annotation of pose keypoints of an object in an image.
         VEHICLE_STATE (optional): The annotation of ego vehicle states.
+        TRAFFIC_LIGHT (optional): The annotation of traffic light states.
     """
 
     ATTRIBUTE = "attribute"
@@ -48,6 +49,7 @@ class SchemaName(str, Enum):
     SURFACE_ANN = "surface_ann"  # optional
     KEYPOINT = "keypoint"  # optional
     VEHICLE_STATE = "vehicle_state"  # optional
+    TRAFFIC_LIGHT = "traffic_light"  # optional
 
     @property
     def filename(self) -> str:
@@ -70,4 +72,5 @@ class SchemaName(str, Enum):
             SchemaName.SURFACE_ANN,
             SchemaName.KEYPOINT,
             SchemaName.VEHICLE_STATE,
+            SchemaName.TRAFFIC_LIGHT,
         )

--- a/t4_devkit/schema/tables/__init__.py
+++ b/t4_devkit/schema/tables/__init__.py
@@ -19,3 +19,4 @@ from .sensor import *  # noqa
 from .surface_ann import *  # noqa
 from .vehicle_state import *  # noqa
 from .visibility import *  # noqa
+from .traffic_light import *  # noqa

--- a/t4_devkit/schema/tables/traffic_light.py
+++ b/t4_devkit/schema/tables/traffic_light.py
@@ -17,10 +17,8 @@ class TrafficLight(SchemaBase):
     Attributes:
         token (str): Unique record identifier.
         instance_token (str): Foreign key pointing to the instance.
-        traffic_light_linestring_id (str): Lane connector ID of the traffic light.
+        primitive_id (str): Primitive ID of the traffic light representing.
     """
 
     instance_token: str = field(validator=(validators.instance_of(str), impossible_empty()))
-    traffic_light_linestring_id: str = field(
-        validator=(validators.instance_of(str), impossible_empty())
-    )
+    primitive_id: str = field(validator=(validators.instance_of(str), impossible_empty()))

--- a/t4_devkit/schema/tables/traffic_light.py
+++ b/t4_devkit/schema/tables/traffic_light.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from attrs import define, field, validators
+
+from ..name import SchemaName
+from .base import SchemaBase, impossible_empty
+from .registry import SCHEMAS
+
+__all__ = ["TrafficLight"]
+
+
+@define(slots=False)
+@SCHEMAS.register(SchemaName.TRAFFIC_LIGHT)
+class TrafficLight(SchemaBase):
+    """A dataclass to represent schema table of `traffic_light.json`.
+
+    Attributes:
+        token (str): Unique record identifier.
+        instance_token (str): Foreign key pointing to the instance.
+        traffic_light_linestring_id (str): Lane connector ID of the traffic light.
+    """
+
+    instance_token: str = field(validator=(validators.instance_of(str), impossible_empty()))
+    traffic_light_linestring_id: str = field(
+        validator=(validators.instance_of(str), impossible_empty())
+    )

--- a/t4_devkit/tier4.py
+++ b/t4_devkit/tier4.py
@@ -40,6 +40,7 @@ if TYPE_CHECKING:
         SchemaTable,
         Sensor,
         SurfaceAnn,
+        TrafficLight,
         VehicleState,
         Visibility,
     )
@@ -204,6 +205,9 @@ class T4Devkit:
             self.annotation_dir, SchemaName.VEHICLE_STATE
         )
         self.visibility: list[Visibility] = load_table(self.annotation_dir, SchemaName.VISIBILITY)
+        self.traffic_light: list[TrafficLight] = load_table(
+            self.annotation_dir, SchemaName.TRAFFIC_LIGHT
+        )
 
         # make reverse indexes for common lookups
         self.__make_reverse_index__(verbose)

--- a/tests/sanity/test_format_checkers.py
+++ b/tests/sanity/test_format_checkers.py
@@ -25,6 +25,7 @@ from t4_devkit.sanity.format.fmt015 import FMT015
 from t4_devkit.sanity.format.fmt016 import FMT016
 from t4_devkit.sanity.format.fmt017 import FMT017  # optional (keypoint) - missing in sample
 from t4_devkit.sanity.format.fmt018 import FMT018
+from t4_devkit.sanity.format.fmt019 import FMT019
 
 # Root of the provided sample dataset (non-versioned)
 SAMPLE_ROOT = Path(__file__).parent.parent.joinpath("sample", "t4dataset")
@@ -55,6 +56,7 @@ ALL_FORMAT_CHECKERS: list[type] = [
     FMT016,
     FMT017,
     FMT018,
+    FMT019,
 ]
 
 

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -19,6 +19,8 @@ from t4_devkit.sanity.reference.ref009 import REF009
 from t4_devkit.sanity.reference.ref010 import REF010
 from t4_devkit.sanity.reference.ref011 import REF011
 from t4_devkit.sanity.reference.ref012 import REF012
+from t4_devkit.sanity.reference.ref013 import REF013
+from t4_devkit.sanity.reference.ref014 import REF014
 from t4_devkit.sanity.reference.ref201 import REF201
 from t4_devkit.sanity.reference.ref202 import REF202
 
@@ -86,6 +88,9 @@ def _ensure_is_valid(records: list[dict]) -> list[dict]:
         REF009,
         REF010,
         REF011,
+        REF012,
+        REF013,
+        REF014,
         REF201,
         REF202,
     ],

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -237,6 +237,51 @@ def test_ref005_fail_invalid_sample_reference(tmp_path: Path) -> None:
     assert any("nonexistent_sample_token" in r for r in report.reasons)
 
 
+def test_ref014_fail_invalid_primitive_ids(tmp_path: Path) -> None:
+    """Check that REF014 rejects an ID belonging to a non-traffic-light primitive."""
+
+    osm = """<osm version="0.6">
+      <node id="1" lat="0.0" lon="0.0"/>
+      <node id="2" lat="0.0" lon="0.0001"/>
+      <node id="3" lat="0.0" lon="0.0002"/>
+
+      <way id="100">
+        <nd ref="1"/>
+        <nd ref="2"/>
+        <tag k="type" v="traffic_light"/>
+      </way>
+
+      <way id="200">
+        <nd ref="2"/>
+        <nd ref="3"/>
+        <tag k="type" v="stop_line"/>
+      </way>
+    </osm>"""
+
+    root = _copy_dataset(tmp_path / "dataset_ref014_fail")
+    (root / "map" / "lanelet2_map.osm").write_text(osm, encoding="utf-8")
+
+    instance_token = _load_json(root / "annotation" / "instance.json")[0]["token"]
+    invalid_primitive_id = "200"
+    _dump_json(
+        root / "annotation" / "traffic_light.json",
+        [
+            {
+                "token": "traffic_light_token",
+                "instance_token": instance_token,
+                "primitive_id": invalid_primitive_id,
+            }
+        ],
+    )
+
+    checker = REF014()
+    report = checker(_context(root))
+
+    assert not report.is_passed(strict=True)
+    assert report.reasons
+    assert any(invalid_primitive_id in reason for reason in report.reasons)
+
+
 def test_ref201_fail_missing_filename(tmp_path: Path) -> None:
     """Mutate sample_data.json to point to a missing file for REF201."""
     root = _copy_dataset(tmp_path / "dataset_ref013_fail")

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -20,7 +20,7 @@ from t4_devkit.sanity.reference.ref010 import REF010
 from t4_devkit.sanity.reference.ref011 import REF011
 from t4_devkit.sanity.reference.ref012 import REF012
 from t4_devkit.sanity.reference.ref013 import REF013
-from t4_devkit.sanity.reference.ref014 import REF014
+from t4_devkit.sanity.reference.ref014 import REF014, _traffic_light_ids
 from t4_devkit.sanity.reference.ref201 import REF201
 from t4_devkit.sanity.reference.ref202 import REF202
 
@@ -280,6 +280,24 @@ def test_ref014_fail_invalid_primitive_ids(tmp_path: Path) -> None:
     assert not report.is_passed(strict=True)
     assert report.reasons
     assert any(invalid_primitive_id in reason for reason in report.reasons)
+
+
+def test_ref014_normalizes_integer_way_ids(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Normalize numeric Lanelet way IDs before comparing them with primitive_id strings."""
+
+    class Way:
+        id = 100
+        tags = {"type": "traffic_light"}
+
+    class Parser:
+        ways = {100: Way()}
+
+    monkeypatch.setattr(
+        "t4_devkit.sanity.reference.ref014.LaneletParser",
+        lambda *_args, **_kwargs: Parser(),
+    )
+
+    assert _traffic_light_ids("lanelet2_map.osm") == {"100"}
 
 
 def test_ref201_fail_missing_filename(tmp_path: Path) -> None:

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -412,7 +412,7 @@ def traffic_light_dict() -> dict:
     return {
         "token": "269572c280bd5cf9630ca542e6a60185",
         "instance_token": "8f37d145617ec022386982a2b43f1539",
-        "traffic_light_linestring_id": "1234",
+        "primitive_id": "1234",
     }
 
 

--- a/tests/schema/conftest.py
+++ b/tests/schema/conftest.py
@@ -403,3 +403,22 @@ def vehicle_state_json(vehicle_state_dict) -> Generator[str, Any, None]:
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
         save_json([vehicle_state_dict], f.name)
         yield f.name
+
+
+# === TrafficLight ===
+@pytest.fixture(scope="session")
+def traffic_light_dict() -> dict:
+    """Return a dummy traffic light as dictionary."""
+    return {
+        "token": "269572c280bd5cf9630ca542e6a60185",
+        "instance_token": "8f37d145617ec022386982a2b43f1539",
+        "traffic_light_linestring_id": "1234",
+    }
+
+
+@pytest.fixture(scope="session")
+def traffic_light_json(traffic_light_dict) -> Generator[str, Any, None]:
+    """Return a file path of dummy traffic light record."""
+    with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
+        save_json([traffic_light_dict], f.name)
+        yield f.name

--- a/tests/schema/tables/test_traffic_light_table.py
+++ b/tests/schema/tables/test_traffic_light_table.py
@@ -28,7 +28,7 @@ def test_new_traffic_light(traffic_light_dict) -> None:
     assert ret.token != traffic_light_dict["token"]
 
 
-@pytest.mark.parametrize("field", ["token", "instance_token", "traffic_light_linestring_id"])
+@pytest.mark.parametrize("field", ["token", "instance_token", "primitive_id"])
 def test_traffic_light_required_fields(traffic_light_dict, field: str) -> None:
     """Test traffic light required fields."""
     invalid = traffic_light_dict.copy()

--- a/tests/schema/tables/test_traffic_light_table.py
+++ b/tests/schema/tables/test_traffic_light_table.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from t4_devkit.common.serialize import serialize_dataclass, serialize_dataclasses
+from t4_devkit.schema import TrafficLight
+
+
+def test_traffic_light_json(traffic_light_json) -> None:
+    """Test loading traffic light from a json file."""
+    schemas = TrafficLight.from_json(traffic_light_json)
+    serialized = serialize_dataclasses(schemas)
+    assert isinstance(serialized, list)
+
+
+def test_traffic_light(traffic_light_dict) -> None:
+    """Test loading traffic light from a dictionary."""
+    schema = TrafficLight.from_dict(traffic_light_dict)
+    serialized = serialize_dataclass(schema)
+    assert serialized == traffic_light_dict
+
+
+def test_new_traffic_light(traffic_light_dict) -> None:
+    """Test generating traffic light with a new token."""
+    without_token = {k: v for k, v in traffic_light_dict.items() if k != "token"}
+    ret = TrafficLight.new(without_token)
+    # check the new token is not the same with the token in input data
+    assert ret.token != traffic_light_dict["token"]
+
+
+@pytest.mark.parametrize("field", ["token", "instance_token", "traffic_light_linestring_id"])
+def test_traffic_light_required_fields(traffic_light_dict, field: str) -> None:
+    """Test traffic light required fields."""
+    invalid = traffic_light_dict.copy()
+    invalid[field] = ""
+
+    with pytest.raises(ValueError):
+        TrafficLight.from_dict(invalid)

--- a/tests/schema/test_schema_name.py
+++ b/tests/schema/test_schema_name.py
@@ -26,6 +26,7 @@ def test_schema_name() -> None:
         "surface_ann": True,
         "keypoint": True,
         "vehicle_state": True,
+        "traffic_light": True,
     }
 
     # check all enum members are covered by above names


### PR DESCRIPTION
## What

This pull request introduces a new schema definition for traffic light relation of object detection.


```json
traffic_light {
  "token":                    <str> -- Unique record identifier.
  "instance_token":           <str> -- Foreign key to the `Instance` table associated with the instance of the object.
  "primitive_id":             <str> -- ID of the lanelet primitive representing the physical lamp unit.
}
```

**Main Changes**

- Add a new schema definition called `TrafficLight` for `traffic_light.json`
  - Enable to load with `T4Devkit` as optional
- Add sanity checks for `traffic_light.json`
  - `FMT019`: Checks if it's possible to load `traffic_light.json`
  - `REF013`: Checks if `TrafficLight.instance_token` refers to `Instance` record
  - `REF014`: Checks if `TrafficLight.traffic_light_linestring_id` refers to a lanelet relation in the map.

## Parent Issues

- [TIER IV INVERNAL LINK](https://tier4.atlassian.net/browse/RDDR-942)