### PR TITLE
fix(sanity): allow first/last annotation token refers to either SampleAnnotation or ObjectAnn record

### DIFF
--- a/docs/schema/requirement.md
+++ b/docs/schema/requirement.md
@@ -30,20 +30,20 @@
 
 ### Record Reference (A to B)
 
-| ID       | Name                                  | Severity | Fixable | Description                                                               |
-| -------- | ------------------------------------- | -------- | ------- | ------------------------------------------------------------------------- |
-| `REF001` | `scene-to-log`                        | `ERROR`  | `N/A`   | `Scene.log_token` refers to `Log` record.                                 |
-| `REF002` | `scene-to-first-sample`               | `ERROR`  | `N/A`   | `Scene.first_sample_token` refers to `Sample` record.                     |
-| `REF003` | `scene-to-last-sample`                | `ERROR`  | `N/A`   | `Scene.last_sample_token` refers to `Sample` record.                      |
-| `REF004` | `sample-to-scene`                     | `ERROR`  | `N/A`   | `Sample.scene_token` refers to `Scene` record.                            |
-| `REF005` | `sample-data-to-sample`               | `ERROR`  | `N/A`   | `SampleData.sample_token` refers to `Sample` record.                      |
-| `REF006` | `sample-data-to-ego-pose`             | `ERROR`  | `N/A`   | `SampleData.ego_pose_token` refers to `EgoPose` record.                   |
-| `REF007` | `sample-data-to-calibrated-sensor`    | `ERROR`  | `N/A`   | `SampleData.calibrated_sensor_token` refers to `CalibratedSensor` record. |
-| `REF008` | `calibrated-sensor-to-sensor`         | `ERROR`  | `N/A`   | `CalibratedSensor.sensor_token` refers to `Sensor` record.                |
-| `REF009` | `instance-to-category`                | `ERROR`  | `N/A`   | `Instance.category_token` refers to `Category` record.                    |
-| `REF010` | `instance-to-first-sample-annotation` | `ERROR`  | `N/A`   | `Instance.first_annotation_token` refers to `SampleAnnotation` record.    |
-| `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `N/A`   | `Instance.last_annotation_token` refers to `SampleAnnotation` record.     |
-| `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `N/A`   | `LidarSeg.sample_data_token` refers to `SampleData` record.               |
+| ID       | Name                                  | Severity | Fixable | Description                                                                           |
+| -------- | ------------------------------------- | -------- | ------- | ------------------------------------------------------------------------------------- |
+| `REF001` | `scene-to-log`                        | `ERROR`  | `N/A`   | `Scene.log_token` refers to `Log` record.                                             |
+| `REF002` | `scene-to-first-sample`               | `ERROR`  | `N/A`   | `Scene.first_sample_token` refers to `Sample` record.                                 |
+| `REF003` | `scene-to-last-sample`                | `ERROR`  | `N/A`   | `Scene.last_sample_token` refers to `Sample` record.                                  |
+| `REF004` | `sample-to-scene`                     | `ERROR`  | `N/A`   | `Sample.scene_token` refers to `Scene` record.                                        |
+| `REF005` | `sample-data-to-sample`               | `ERROR`  | `N/A`   | `SampleData.sample_token` refers to `Sample` record.                                  |
+| `REF006` | `sample-data-to-ego-pose`             | `ERROR`  | `N/A`   | `SampleData.ego_pose_token` refers to `EgoPose` record.                               |
+| `REF007` | `sample-data-to-calibrated-sensor`    | `ERROR`  | `N/A`   | `SampleData.calibrated_sensor_token` refers to `CalibratedSensor` record.             |
+| `REF008` | `calibrated-sensor-to-sensor`         | `ERROR`  | `N/A`   | `CalibratedSensor.sensor_token` refers to `Sensor` record.                            |
+| `REF009` | `instance-to-category`                | `ERROR`  | `N/A`   | `Instance.category_token` refers to `Category` record.                                |
+| `REF010` | `instance-to-first-sample-annotation` | `ERROR`  | `N/A`   | `Instance.first_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record. |
+| `REF011` | `instance-to-last-sample-annotation`  | `ERROR`  | `N/A`   | `Instance.last_annotation_token` refers to `SampleAnnotation` or `ObjectAnn` record.  |
+| `REF012` | `lidarseg-to-sample-data`             | `ERROR`  | `N/A`   | `LidarSeg.sample_data_token` refers to `SampleData` record.                           |
 
 ### Record Reference (A to A')
 

--- a/t4_devkit/sanity/reference/base.py
+++ b/t4_devkit/sanity/reference/base.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from returns.maybe import Maybe, Nothing, Some
+from returns.pipeline import is_successful
 
 from ..checker import Checker
 from ..result import Reason
@@ -23,33 +24,46 @@ class RecordReferenceChecker(Checker):
         severity (Severity): The severity of the rule.
         description (str): The description of the rule.
         source (SchemaName): The source schema name.
-        target (SchemaName): The target schema name.
+        target (SchemaName | list[SchemaName]): The target schema name(s).
         reference (str): The reference token name in the source record.
     """
 
     source: SchemaName
-    target: SchemaName
+    target: SchemaName | list[SchemaName]
     reference: str
 
     def can_skip(self, context: SanityContext) -> Maybe[Reason]:
+        target_schemas = self.target if isinstance(self.target, list) else [self.target]
         source_file = context.to_schema_file(self.source)
-        target_file = context.to_schema_file(self.target)
-        match (source_file, target_file):
-            case Some(x), Some(y):
+        target_files = [context.to_schema_file(t) for t in target_schemas]
+        match (source_file, *target_files):
+            case Some(x), *ys:
+                target_file_paths = [y.unwrap() for y in ys if is_successful(y)]
                 if not x.exists():
                     return Maybe.from_value(Reason(f"Missing {self.source.filename}"))
-                elif not y.exists():
-                    return Maybe.from_value(Reason(f"Missing {self.target.filename}"))
+                elif not any(path.exists() for path in target_file_paths):
+                    return Maybe.from_value(
+                        Reason(f"Missing {', '.join(t.filename for t in target_schemas)}")
+                    )
                 else:
                     return Nothing
             case _:
                 return Maybe.from_value(Reason("Missing 'annotation' directory path"))
 
     def check(self, context: SanityContext) -> list[Reason] | None:
+        target_schemas = self.target if isinstance(self.target, list) else [self.target]
         source_file = context.to_schema_file(self.source).unwrap()
-        target_file = context.to_schema_file(self.target).unwrap()
+        target_files = [
+            target_file.unwrap()
+            for target_file in [context.to_schema_file(t) for t in target_schemas]
+            if is_successful(target_file) and target_file.unwrap().exists()
+        ]
         source_records = load_json_safe(source_file).unwrap()
-        target_tokens = [item["token"] for item in load_json_safe(target_file).unwrap()]
+        target_tokens = [
+            item["token"]
+            for target_file in target_files
+            for item in load_json_safe(target_file).unwrap()
+        ]
         return [
             Reason(
                 f"No reference to '{self.source.value}.{self.reference}': {record[self.reference]}"

--- a/t4_devkit/sanity/reference/ref010.py
+++ b/t4_devkit/sanity/reference/ref010.py
@@ -16,7 +16,9 @@ class REF010(RecordReferenceChecker):
     id = RuleID("REF010")
     name = RuleName("instance-to-first-sample-annotation")
     severity = Severity.ERROR
-    description = "'Instance.first_annotation_token' refers to 'SampleAnnotation' record."
+    description = (
+        "'Instance.first_annotation_token' refers to 'SampleAnnotation' or 'ObjectAnn' record."
+    )
     source = SchemaName.INSTANCE
-    target = SchemaName.SAMPLE_ANNOTATION
+    target = [SchemaName.SAMPLE_ANNOTATION, SchemaName.OBJECT_ANN]
     reference = "first_annotation_token"

--- a/t4_devkit/sanity/reference/ref011.py
+++ b/t4_devkit/sanity/reference/ref011.py
@@ -16,7 +16,9 @@ class REF011(RecordReferenceChecker):
     id = RuleID("REF011")
     name = RuleName("instance-to-last-sample-annotation")
     severity = Severity.ERROR
-    description = "'Instance.last_annotation_token' refers to 'SampleAnnotation' record."
+    description = (
+        "'Instance.last_annotation_token' refers to 'SampleAnnotation' or 'ObjectAnn' record."
+    )
     source = SchemaName.INSTANCE
-    target = SchemaName.SAMPLE_ANNOTATION
+    target = [SchemaName.SAMPLE_ANNOTATION, SchemaName.OBJECT_ANN]
     reference = "last_annotation_token"

--- a/tests/sanity/test_reference_checkers.py
+++ b/tests/sanity/test_reference_checkers.py
@@ -124,6 +124,40 @@ def test_ref012_skipped_on_missing_sources() -> None:
     assert report.is_skipped(), "REF012 should be skipped when source/target file missing"
 
 
+@pytest.mark.parametrize(
+    "checker_cls, reference_key, object_ann_index",
+    [
+        (REF010, "first_annotation_token", 0),
+        (REF011, "last_annotation_token", 1),
+    ],
+)
+def test_instance_annotation_reference_uses_existing_target_when_one_target_missing(
+    checker_cls: type,
+    reference_key: str,
+    object_ann_index: int,
+    tmp_path: Path,
+) -> None:
+    """REF010/REF011 should read existing targets when sample_annotation.json is absent."""
+    root = _copy_dataset(tmp_path / f"dataset_{checker_cls.__name__}_missing_sample_ann")
+    ann_dir = root / "annotation"
+    if not ann_dir.exists():
+        ann_dir = root / "sample" / "t4dataset" / "annotation"
+
+    object_ann_records = _load_json(ann_dir / "object_ann.json")
+    instance_records = _load_json(ann_dir / "instance.json")
+    for index, record in enumerate(instance_records):
+        object_ann = object_ann_records[(index + object_ann_index) % len(object_ann_records)]
+        record[reference_key] = object_ann["token"]
+    _dump_json(ann_dir / "instance.json", instance_records)
+    (ann_dir / "sample_annotation.json").unlink()
+
+    checker = checker_cls()
+    report = checker(_context(root))
+
+    assert report.is_passed(strict=True)
+    assert report.reasons is None
+
+
 # ---------------------------------------------------------------------------
 # FAIL (invalid references) tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

This pull request fixes sanity checks `REF010` and `REF011`.

Previously, above checks restricted that `Instance.first_annotation_token` and `Instance.last_annotation_token` refer to `SampleAnnotation` record.
However, there is a case that these tokens refer to `ObjectAnn` record.

As of this pull request `REF010` and `REF011` allow these tokens refer to either `SampleAnnotation` or `ObjectAnn` record.